### PR TITLE
Fix: First LP Dust

### DIFF
--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -343,6 +343,10 @@ impl PoolTrait for Pool {
         // First deposit: mint MIN_LIQUIDITY to contract itself to prevent dust attacks
         if total_shares == 0 {
             mint_lp_tokens(&e, &e.current_contract_address(), MIN_LIQUIDITY as i128);
+            
+            let events = LiquidityPoolEvents::new(&e);
+            events.permanently_locked_liquidity(MIN_LIQUIDITY);
+            
             shares_to_mint = shares_to_mint.saturating_sub(MIN_LIQUIDITY);
         }
 
@@ -827,6 +831,10 @@ impl PoolTrait for Pool {
         burn_lp_tokens(&e, &user, share_amount);
 
         let (_, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
+
+        if total_shares - share_amount < MIN_LIQUIDITY {
+            panic_with_error!(e, PoolError::WithdrawExceedsMinLiquidity);
+        }
 
         // Transfer any remaining to the user
         transfer_b(&e, &user, share_amount);

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -98,6 +98,7 @@ use utils::constant::{
     INSURANCE_C_MAX,
     INSURANCE_SPECULATIVE_MAX,
     MAX_POOL_FEE,
+    MIN_LIQUIDITY,
 };
 use utils::math::safe_math::SafeMath;
 use utils::state::oracle_registry::NormalAction;
@@ -337,7 +338,13 @@ impl PoolTrait for Pool {
 
         // Now calculate how many new pool shares to mint
         let total_shares = get_total_lp_tokens(&e);
-        let shares_to_mint = token_b_amount;
+        let mut shares_to_mint = token_b_amount;
+
+        // First deposit: mint MIN_LIQUIDITY to contract itself to prevent dust attacks
+        if total_shares == 0 {
+            mint_lp_tokens(&e, &e.current_contract_address(), MIN_LIQUIDITY as i128);
+            shares_to_mint = shares_to_mint.saturating_sub(MIN_LIQUIDITY);
+        }
 
         mint_lp_tokens(&e, &user, shares_to_mint as i128);
 
@@ -1139,6 +1146,29 @@ impl AdminInterfaceTrait for Pool {
         pool.status = status;
 
         set_pool(&e, &pool);
+
+        // Automatically recover minimum liquidity when pool is delisted
+        if status == PoolStatus::Delisted {
+            let contract_address = e.current_contract_address();
+            let locked_balance = get_user_balance_lp(&e, &contract_address);
+            
+            if locked_balance > 0 {
+                // Burn the locked LP tokens from contract
+                burn_lp_tokens(&e, &contract_address, locked_balance as i128);
+                
+                // Calculate the underlying Token B amount
+                let total_shares = get_total_lp_tokens(&e);
+                let reserve_b = get_reserve_b(&e);
+                let token_b_amount = if total_shares > 0 {
+                    (locked_balance * reserve_b) / total_shares
+                } else {
+                    locked_balance // fallback to 1:1 if no other shares
+                };
+                
+                // Transfer Token B to admin (operations admin or owner who delisted the pool)
+                transfer_b(&e, &admin, token_b_amount);
+            }
+        }
     }
 
     fn set_max_imbalances(
@@ -1216,6 +1246,7 @@ impl AdminInterfaceTrait for Pool {
 
         set_pool(&e, &pool);
     }
+
 
     //    _______     __       ____  ____   ________  _______  ________
     //   |   __ "\   /""\     ("  _||_ " | /"       )/"     "||"      "\

--- a/contracts/pool/src/errors.rs
+++ b/contracts/pool/src/errors.rs
@@ -25,6 +25,7 @@ pub enum PoolError {
     // other
     SwapReduceOnly = 217,
     PoolNotDelisted = 218,
+    WithdrawExceedsMinLiquidity = 219,
 }
 
 #[contracterror]

--- a/contracts/pool/src/errors.rs
+++ b/contracts/pool/src/errors.rs
@@ -24,6 +24,7 @@ pub enum PoolError {
     DefaultError = 216,
     // other
     SwapReduceOnly = 217,
+    PoolNotDelisted = 218,
 }
 
 #[contracterror]

--- a/contracts/pool/src/events.rs
+++ b/contracts/pool/src/events.rs
@@ -72,6 +72,8 @@ pub trait PoolEvents {
     fn kill_claim(&self);
 
     fn unkill_claim(&self);
+
+    fn permanently_locked_liquidity(&self, amount: u128);
 }
 
 impl PoolEvents for Events {
@@ -184,5 +186,13 @@ impl PoolEvents for Events {
         self.env()
             .events()
             .publish((Symbol::new(self.env(), "unkill_claim"),), ())
+    }
+
+    fn permanently_locked_liquidity(&self, amount: u128) {
+        let e = self.env();
+        e.events().publish(
+            (Symbol::new(e, "permanently_locked_liquidity"),),
+            amount
+        );
     }
 }

--- a/contracts/pool/src/interface.rs
+++ b/contracts/pool/src/interface.rs
@@ -139,6 +139,9 @@ pub trait AdminInterfaceTrait {
 
     fn set_expiry(e: Env, admin: Address, expiry_ts: u64);
 
+    // Recover minimum liquidity locked tokens when pool is delisted
+    fn recover_minimum_liquidity(e: Env, admin: Address) -> u128;
+
     //    _______     __       ____  ____   ________  _______  ________
     //   |   __ "\   /""\     ("  _||_ " | /"       )/"     "||"      "\
     //   (. |__) :) /    \    |   (  ) : |(:   \___/(: ______)(.  ___  :)

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -53,6 +53,9 @@ pub const PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128: i128 =
 pub const FEE_MULTIPLIER: u128 = 10_000;
 pub const DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR: i64 = 3; // '3' here means clamp new data point to 33% (1/3) divergence from current twap (if twap > 0)
 
+
+pub const MIN_LIQUIDITY: u128 = 1_000;
+
 // Pool Router
 pub const MAX_POOL_FEE: u32 = 100; // 1%
 


### PR DESCRIPTION
## Summary
  - **Automated minimum liquidity recovery**: Modified `set_status` function to automatically trigger minimum liquidity
  recovery when a pool is set to `Delisted` status
  - **Streamlined workflow**: Pool delisting now automatically recovers locked minimum liquidity tokens and transfers the
  underlying Token B amount to the admin who initiated the delisting
  - **Minimum balance validation** - Added validation to always make sure the pool has atleast the funds to send back to the admin
