### PR TITLE
fix: replace blocking utilization check with better validation

### DIFF
--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -38,6 +38,7 @@ use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
 use utils::math::safe_math::SafeMath;
 use utils::token::transfer_token;
 use utils::validate;
+use utils::validation::validate_percentages;
 
 contractmeta!(
     key = "Description",
@@ -58,7 +59,7 @@ impl InsuranceFundTrait for InsuranceFund {
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
-        rate_slopes: (u32, u32),
+        rate_slopes: (u32, u32)
     ) {
         admin.require_auth();
 
@@ -645,14 +646,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         let (slope1, slope2) = (get_rate_slope_a(&e), get_rate_slope_b(&e));
 
-        calculate_rate(
-            &e,
-            utilization,
-            optimal_utilization,
-            base_rate,
-            slope1,
-            slope2,
-        )
+        calculate_rate(utilization, optimal_utilization, base_rate, slope1, slope2)
     }
 
     fn get_base_rate(e: Env) -> i32 {
@@ -846,10 +840,20 @@ impl AdminInterface for InsuranceFund {
         optimal_utilization: u32,
         base_rate: i32,
         rate_slope_a: u32,
-        rate_slope_b: u32,
+        rate_slope_b: u32
     ) {
         admin.require_auth();
         require_admin(&e, &admin);
+
+        validate_percentages(
+            &e,
+            &Vec::from_array(&e, [
+                optimal_utilization as i32,
+                base_rate,
+                rate_slope_a as i32,
+                rate_slope_b as i32,
+            ])
+        );
 
         set_optimal_utilization(&e, &optimal_utilization);
         set_base_rate(&e, &base_rate);

--- a/contracts/insurance_fund/src/errors.rs
+++ b/contracts/insurance_fund/src/errors.rs
@@ -24,8 +24,6 @@ pub enum InsuranceFundError {
     InvalidIFDetected = 19,
     TooMuchInsurance = 20,
 
-    InvalidOptimalUtilization = 21,
-
     // paused ops
     FundDepositKilled = 30,
     FundRequestWithdrawKilled = 31,

--- a/contracts/insurance_fund/src/interest.rs
+++ b/contracts/insurance_fund/src/interest.rs
@@ -1,8 +1,5 @@
 use soroban_fixed_point_math::FixedPoint;
-use soroban_sdk::{panic_with_error, Env};
-use utils::constant::PERCENTAGE_PRECISION;
-
-use crate::errors::InsuranceFundError;
+use utils::constant::{ PERCENTAGE_PRECISION, PERCENTAGE_PRECISION_I64 };
 
 // Calculates the utilization percentage of the insurance fund.
 //
@@ -13,7 +10,7 @@ use crate::errors::InsuranceFundError;
 //
 // # Returns
 //
-// * The utilization percentage as a fixed-point `u32` (e.g. 1_000_000 = 100%).
+// * The utilization percentage as a fixed-point `u32` (e.g. 10_000_000 = 100%).
 //   Returns 0 if either input is zero. The result is scaled by `PERCENTAGE_PRECISION`.
 pub fn calculate_utilization(insurance_vault_amount: u128, optimal_insurance: u128) -> u32 {
     if insurance_vault_amount == 0 || optimal_insurance == 0 {
@@ -42,19 +39,14 @@ pub fn calculate_utilization(insurance_vault_amount: u128, optimal_insurance: u1
 //
 // * The calculated interest rate in basis points as an `i32`.
 pub fn calculate_rate(
-    e: &Env,
     utilization: u32,
     optimal_utilization: u32,
     base_rate: i32,
     slope1: u32,
-    slope2: u32,
+    slope2: u32
 ) -> i32 {
     if utilization == 0 {
         return base_rate;
-    }
-
-    if optimal_utilization == 0 || optimal_utilization >= 10_000 {
-        panic_with_error!(e, InsuranceFundError::InvalidOptimalUtilization);
     }
 
     let utilization = utilization as i64;
@@ -65,14 +57,12 @@ pub fn calculate_rate(
 
     let rate = if utilization <= optimal_utilization {
         // rate = base + (utilization * slope1 / optimal_utilization)
-        let variable_rate = utilization
-            .fixed_mul_floor(slope1, optimal_utilization)
-            .unwrap();
+        let variable_rate = utilization.fixed_mul_floor(slope1, optimal_utilization).unwrap();
         base_rate + variable_rate
     } else {
-        // rate = base + slope1 + ((utilization - optimal_utilization) * slope2 / (10_000 - optimal_utilization))
+        // rate = base + slope1 + ((utilization - optimal_utilization) * slope2 / (10_000_000 - optimal_utilization))
         let excess_util = utilization - optimal_utilization;
-        let remaining = 10_000 - optimal_utilization;
+        let remaining = PERCENTAGE_PRECISION_I64 - optimal_utilization;
 
         let slope2_part = excess_util.fixed_mul_floor(slope2, remaining).unwrap();
 
@@ -84,7 +74,7 @@ pub fn calculate_rate(
 
 #[cfg(test)]
 mod tests {
-    use utils::constant::{PERCENTAGE_PRECISION_U32, PRICE_PRECISION};
+    use utils::constant::{ PERCENTAGE_PRECISION_U32, PRICE_PRECISION };
 
     use super::*;
 
@@ -92,22 +82,28 @@ mod tests {
 
     #[test]
     fn test_utilization_100_percent() {
-        let utilization =
-            calculate_utilization(1_000_000 * PRICE_PRECISION, 1_000_000 * PRICE_PRECISION);
+        let utilization = calculate_utilization(
+            1_000_000 * PRICE_PRECISION,
+            1_000_000 * PRICE_PRECISION
+        );
         assert_eq!(utilization, 1 * PERCENTAGE_PRECISION_U32);
     }
 
     #[test]
     fn test_utilization_50_percent() {
-        let utilization =
-            calculate_utilization(500_000 * PRICE_PRECISION, 1_000_000 * PRICE_PRECISION);
+        let utilization = calculate_utilization(
+            500_000 * PRICE_PRECISION,
+            1_000_000 * PRICE_PRECISION
+        );
         assert_eq!(utilization, 5_000_000); // 0.5%
     }
 
     #[test]
     fn test_utilization_above_100_percent() {
-        let utilization =
-            calculate_utilization(2_000_000 * PRICE_PRECISION, 1_000_000 * PRICE_PRECISION);
+        let utilization = calculate_utilization(
+            2_000_000 * PRICE_PRECISION,
+            1_000_000 * PRICE_PRECISION
+        );
         assert_eq!(utilization, 2 * PERCENTAGE_PRECISION_U32);
     }
 
@@ -133,15 +129,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #21)")]
     fn test_zero_optimal_utilization() {
-        let e = Env::default();
         // optimal_utilization = 0 could panic on division unless handled
-        calculate_rate(&e, 5000, 0, 100, 400, 1500);
+        calculate_rate(5000, 0, 100, 400, 1500);
     }
 
     #[test]
     fn test_utilization_above_100_percent_in_rate() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 11_000, 8000, 100, 400, 1500);
+        let rate = calculate_rate(11_000, 8000, 100, 400, 1500);
         // excess = 3000, remaining = 2000
         // rate = 100 + 400 + (3000 / 2000) * 1500 = 100 + 400 + 2250 = 2750
         assert_eq!(rate, 2750);
@@ -151,55 +145,48 @@ mod tests {
 
     #[test]
     fn test_zero_utilization() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 0, 8000, 100, 400, 1500);
+        let rate = calculate_rate(0, 8000, 100, 400, 1500);
         assert_eq!(rate, 100); // Only base rate should apply
     }
 
     #[test]
     fn test_negative_base_rate() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 5000, 8000, -100, 400, 1500);
+        let rate = calculate_rate(5000, 8000, -100, 400, 1500);
         // -100 + (5000 / 8000 * 400) = -100 + 250 = 150
         assert_eq!(rate, 150);
     }
 
     #[test]
     fn test_negative_rate() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 11000, 8000, -1000, 200, 1000);
+        let rate = calculate_rate(11000, 8000, -1000, 200, 1000);
         // -100 + (5000 / 8000 * 400) = -100 + 250 = 150
         assert_eq!(rate, -975);
     }
 
     #[test]
     fn test_low_utilization_rate() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 5000, 8000, 100, 400, 1500);
+        let rate = calculate_rate(5000, 8000, 100, 400, 1500);
         // 100 + (5000 / 8000 * 400) = 100 + 250 = 350
         assert_eq!(rate, 350);
     }
 
     #[test]
     fn test_utilization_at_optimal() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 8000, 8000, 100, 400, 1500);
+        let rate = calculate_rate(8000, 8000, 100, 400, 1500);
         // base + slope_a = 100 + 400 = 500
         assert_eq!(rate, 500);
     }
 
     #[test]
     fn test_high_utilization_rate() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 9500, 8000, 100, 400, 1500);
+        let rate = calculate_rate(9500, 8000, 100, 400, 1500);
         // base + slope_a + ((1500 / 2000) * 1500) = 100 + 400 + 1125 = 1625
         assert_eq!(rate, 1625);
     }
 
     #[test]
     fn test_max_utilization() {
-        let e = Env::default();
-        let rate = calculate_rate(&e, 10_000, 8000, 100, 400, 1500);
+        let rate = calculate_rate(10_000, 8000, 100, 400, 1500);
         // base + slope_a + slope_b = 100 + 400 + 1500 = 2000
         assert_eq!(rate, 2000);
     }

--- a/modules/utils/src/errors/validation_errors.rs
+++ b/modules/utils/src/errors/validation_errors.rs
@@ -6,4 +6,5 @@ use soroban_sdk::contracterror;
 pub enum ValidationError {
     #[doc = "ValidationError"]
     InvalidToken = 801,
+    InvalidPercentage = 802,
 }

--- a/modules/utils/src/lib.rs
+++ b/modules/utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod macros;
 pub mod math;
 pub mod state;
 pub mod token;
+pub mod validation;
 
 pub mod test;
 #[cfg(any(test, feature = "testutils"))]

--- a/modules/utils/src/validation.rs
+++ b/modules/utils/src/validation.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::{ panic_with_error, Env, Vec };
+
+use crate::{ constant::PERCENTAGE_PRECISION_I32, errors::validation_errors::ValidationError };
+
+pub fn validate_percentages(e: &Env, values: &Vec<i32>) {
+    for value in values.iter() {
+        if value > PERCENTAGE_PRECISION_I32 || value < -PERCENTAGE_PRECISION_I32 {
+            panic_with_error!(e, ValidationError::InvalidPercentage);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where the appropriate basis point values do not fit within the check in calculate_rate(), keeping the get_rate() method from working. It's replaced with a reusable validation function that can be applied to any number of percentage values.