### PR TITLE
[Fix(HAL-001)]: Dust-Initialisation / Fee-Skimming Risk — totalLP Can Fall to 0

### DIFF
--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -340,6 +340,14 @@ impl PoolTrait for Pool {
         let total_shares = get_total_lp_tokens(&e);
         let shares_to_mint = token_b_amount;
 
+        // First deposit: mint MIN_LIQUIDITY to contract itself to prevent dust attacks
+        if total_shares == 0 {
+            mint_lp_tokens(&e, &e.current_contract_address(), MIN_LIQUIDITY as i128);
+            let events = LiquidityPoolEvents::new(&e);
+            events.permanently_locked_liquidity(MIN_LIQUIDITY);
+            shares_to_mint = shares_to_mint.saturating_sub(MIN_LIQUIDITY);
+        }
+
         mint_lp_tokens(&e, &user, shares_to_mint as i128);
 
         // Checkpoint resulting working balance
@@ -871,6 +879,10 @@ impl PoolTrait for Pool {
 
         let (_, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
 
+        if total_shares - share_amount < MIN_LIQUIDITY {
+            panic_with_error!(e, PoolError::WithdrawExceedsMinLiquidity);
+        }
+
         // Transfer any remaining to the user
         transfer_b(&e, &user, share_amount);
         set_reserve_b(&e, &(reserve_b - share_amount));
@@ -1190,6 +1202,24 @@ impl AdminInterfaceTrait for Pool {
         pool.status = status;
 
         set_pool(&e, &pool);
+                // Automatically recover minimum liquidity when pool is delisted
+        if status == PoolStatus::Delisted {
+                let contract_address = e.current_contract_address();
+                let locked_balance = get_user_balance_lp(&e, &contract_address);
+        
+                if locked_balance > 0 {
+                        burn_lp_tokens(&e, &contract_address, locked_balance as i128);
+        
+                    let total_shares = get_total_lp_tokens(&e);
+                    let reserve_b = get_reserve_b(&e);
+                    let token_b_amount = if total_shares > 0 {
+                        (locked_balance * reserve_b) / total_shares
+                    } else {
+                        locked_balance 
+                    };
+                    transfer_b(&e, &admin, token_b_amount);
+                    }
+                }
     }
 
     fn set_max_imbalances(

--- a/contracts/pool/src/errors.rs
+++ b/contracts/pool/src/errors.rs
@@ -24,6 +24,8 @@ pub enum PoolError {
     DefaultError = 216,
     // other
     SwapReduceOnly = 217,
+    PoolNotDelisted = 218,
+    WithdrawExceedsMinLiquidity = 219,
 }
 
 #[contracterror]

--- a/contracts/pool/src/events.rs
+++ b/contracts/pool/src/events.rs
@@ -53,6 +53,8 @@ pub trait PoolEvents {
     fn kill_claim(&self);
 
     fn unkill_claim(&self);
+
+    fn permanently_locked_liquidity(&self, amount: u128);
 }
 
 // This trait is used to emit events related to liquidity pool operations.
@@ -189,5 +191,13 @@ impl PoolEvents for Events {
         self.env()
             .events()
             .publish((Symbol::new(self.env(), "unkill_claim"),), ())
+    }
+
+    fn permanently_locked_liquidity(&self, amount: u128) {
+        let e = self.env();
+        e.events().publish(
+            (Symbol::new(e, "permanently_locked_liquidity"),),
+            amount
+        );
     }
 }

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -53,6 +53,9 @@ pub const PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128: i128 =
 pub const FEE_MULTIPLIER: u128 = 10_000;
 pub const DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR: i64 = 3; // '3' here means clamp new data point to 33% (1/3) divergence from current twap (if twap > 0)
 
+// Minimum liquidity locked permanently on first deposit to prevent dust attacks
+pub const MIN_LIQUIDITY: u128 = 1_000;
+
 // Pool Router
 pub const MAX_POOL_FEE: u32 = 100; // 1%
 


### PR DESCRIPTION
## Summary
  - **Automated minimum liquidity recovery**: Modified `set_status` function to automatically trigger minimum liquidity
  recovery when a pool is set to `Delisted` status
  - **Streamlined workflow**: Pool delisting now automatically recovers locked minimum liquidity tokens and transfers the
  underlying Token B amount to the admin who initiated the delisting
  - **Minimum balance validation** - Added validation to always make sure the pool has atleast the funds to send back to the admin