### PR TITLE
[Fix(HAL-06)] Avoid self transfer to prevent lockin

### DIFF
--- a/modules/access_control/src/transfer.rs
+++ b/modules/access_control/src/transfer.rs
@@ -48,6 +48,12 @@ impl TransferOwnershipTrait for AccessControl {
             panic_with_error!(&self.0, AccessControlError::AnotherActionActive);
         }
 
+        if let Some(current_address) = self.get_role_safe(role) {
+            if current_address == *future_address {
+                panic_with_error!(&self.0, AccessControlError::BadRoleUsage);
+            }
+        }
+
         let deadline = self.0.ledger().timestamp() + ADMIN_ACTIONS_DELAY;
         self.put_transfer_ownership_deadline(role, deadline);
 


### PR DESCRIPTION
This PR avoids self transfer utilising the `management.rs -> get_role_safe()` function