### PR TITLE
[Fix(HAL-05)] Oracle updation timestamps updates to now

### DIFF
--- a/contracts/oracle_registry/src/contract.rs
+++ b/contracts/oracle_registry/src/contract.rs
@@ -427,6 +427,7 @@ impl AdminInterface for OracleRegistry {
         // Rate limit
         // @dev The timestamp of the last override is not tracked, meaning any
         // update to the oracle will reset this counter. May be changed in the future.
+        // Update: Fixed this, now lst_updated is updated to the current time.
         if now - oracle.last_updated <= oracle_guard_rails.validity.seconds_before_stale_for_pool {
             panic_with_error!(&e, OracleRegistryError::PriceOverrideTooSoon);
         }
@@ -440,6 +441,13 @@ impl AdminInterface for OracleRegistry {
             now,
             false
         );
+
+        // Update the oracle's last_updated timestamp to enforce cooldown
+        let updated_oracle = OracleInfo {
+            last_updated: now,
+            ..oracle
+        };
+        put_oracle(&e, &asset, &updated_oracle);
     }
 
     // TODO: Add unregister oracle function - what does this mean for pools using that oracle?

--- a/contracts/oracle_registry/src/storage_types.rs
+++ b/contracts/oracle_registry/src/storage_types.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::contracttype;
 use utils::{
-    constant::{ PERCENTAGE_PRECISION_U64, PRICE_PRECISION },
+    constant::{ FIVE_SECONDS, PERCENTAGE_PRECISION_U64, PRICE_PRECISION },
     errors::oracle_error::OracleError,
     state::oracle_registry::OraclePriceData,
 };
@@ -70,7 +70,7 @@ impl Default for OracleGuardRails {
                 oracle_twap_percent_divergence: PERCENTAGE_PRECISION_U64 / 10, // 10%
             },
             validity: ValidityGuardRails {
-                seconds_before_stale_for_pool: 5,
+                seconds_before_stale_for_pool: FIVE_SECONDS,
                 too_volatile_ratio: 120, // allows up to ±20%
             },
         }

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -63,6 +63,7 @@ pub const FEE_DENOMINATOR: u32 = 10000;
 pub const REWARD_PRECISION: u128 = 1_000_000_000_000_000_0000000;
 
 // TIME PERIODS
+pub const FIVE_SECONDS: u64 = 5;
 pub const ONE_MINUTE: i128 = 60_i128;
 pub const FIVE_MINUTE: i128 = (60 * 5) as i128;
 pub const ONE_HOUR: u64 = 3600;


### PR DESCRIPTION
This PR addresses the issue of oracle prices being overridden always due to lack of proper `now` time value