### PR TITLE
[Fix(HAL-012)]: PoolRouter Reward Front-Run Enables Zero-Emission Griefing

### DIFF
--- a/contracts/pool_router/src/contract.rs
+++ b/contracts/pool_router/src/contract.rs
@@ -617,10 +617,18 @@ impl IncentivesInterfaceTrait for PoolRouter {
     //
     // # Arguments
     //
+    // * `user` - The address of the user.
     // * `asset` - A vector of token addresses for which to fill the liquidity.
-    fn fill_liquidity(e: Env, asset: Symbol) {
+    fn fill_liquidity(e: Env, user: Address, asset: Symbol) {
+        user.require_auth();
+        require_rewards_admin_or_owner(&e, &user);
+
         let calculator = get_liquidity_calculator(&e);
         let total_liquidity = get_total_liquidity(&e, asset.clone(), calculator);
+
+        if total_liquidity == U256::from_u32(&e, 0) {
+            return;
+        }
 
         let pool_with_processed_info = (total_liquidity.clone(), false);
 
@@ -646,6 +654,7 @@ impl IncentivesInterfaceTrait for PoolRouter {
     //
     // # Arguments
     //
+    // * `user` - The address of the user.
     // * `asset` - A vector of token addresses that the pool consists of.
     //
     // # Returns
@@ -659,7 +668,10 @@ impl IncentivesInterfaceTrait for PoolRouter {
     // * The pool does not exist.
     // * The tokens are not found in the current rewards configuration.
     // * The liquidity for the tokens has not been filled.
-    fn config_pool_rewards(e: Env, asset: Symbol) -> u128 {
+    fn config_pool_rewards(e: Env, user: Address, asset: Symbol) -> u128 {
+        user.require_auth();
+        require_rewards_admin_or_owner(&e, &user);
+
         let pool_id = get_pool(&e, &asset);
 
         let rewards_config = get_rewards_config(&e);

--- a/contracts/pool_router/src/pool_interface.rs
+++ b/contracts/pool_router/src/pool_interface.rs
@@ -117,7 +117,7 @@ pub trait IncentivesInterfaceTrait {
     );
 
     // Fills the aggregated liquidity information for a given set of tokens.
-    fn fill_liquidity(e: Env, asset: Symbol);
+    fn fill_liquidity(e: Env, user: Address, asset: Symbol);
 
     // Configures the rewards for a specific pool.
     //
@@ -140,7 +140,7 @@ pub trait IncentivesInterfaceTrait {
     // * The pool does not exist.
     // * The tokens are not found in the current rewards configuration.
     // * The liquidity for the tokens has not been filled.
-    fn config_pool_rewards(e: Env, asset: Symbol) -> u128;
+    fn config_pool_rewards(e: Env, user: Address, asset: Symbol) -> u128;
 
     // Get rewards status for the pool,
     // including amount available for the user
@@ -166,12 +166,7 @@ pub trait IncentivesInterfaceTrait {
     fn get_total_outstanding_reward(e: Env, asset: Symbol) -> u128;
 
     // Transfer outstanding reward to the pool
-    fn distribute_outstanding_reward(
-        e: Env,
-        user: Address,
-        from: Address,
-        asset: Symbol
-    ) -> u128;
+    fn distribute_outstanding_reward(e: Env, user: Address, from: Address, asset: Symbol) -> u128;
 
     // Claim reward as a user.
     // returns amount of tokens rewarded to the user

--- a/contracts/pool_router/src/test.rs
+++ b/contracts/pool_router/src/test.rs
@@ -308,10 +308,10 @@ fn test_simple_ongoing_reward() {
         &rewards
     );
     e.cost_estimate().budget().reset_default();
-    router.fill_liquidity(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
     e.cost_estimate().budget().print();
     e.cost_estimate().budget().reset_default();
-    let pool_tps = router.config_pool_rewards(&setup.btc_asset);
+    let pool_tps = router.config_pool_rewards(&admin, &setup.btc_asset);
     // e.cost_estimate().budget().print();
     // e.cost_estimate().budget().reset_unlimited();
 
@@ -420,10 +420,10 @@ fn test_rewards_distribution() {
         &e.ledger().timestamp().saturating_add(60),
         &rewards
     );
-    router.fill_liquidity(&setup.btc_asset);
-    router.fill_liquidity(&setup.eth_asset);
-    let pool_tps1 = router.config_pool_rewards(&setup.btc_asset);
-    let pool_tps2 = router.config_pool_rewards(&setup.eth_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.eth_asset);
+    let pool_tps1 = router.config_pool_rewards(&admin, &setup.btc_asset);
+    let pool_tps2 = router.config_pool_rewards(&admin, &setup.eth_asset);
     assert_eq!(pool_tps1, pool_tps2);
 
     let pool_tps = pool_tps1;
@@ -511,8 +511,8 @@ fn test_rewards_distribution_as_operator() {
         &e.ledger().timestamp().saturating_add(60),
         &rewards
     );
-    router.fill_liquidity(&setup.btc_asset);
-    let pool_tps = router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    let pool_tps = router.config_pool_rewards(&admin, &setup.btc_asset);
 
     // 30 seconds passed, half of the reward is available for the user
     jump(&e, 30);
@@ -585,8 +585,8 @@ fn test_rewards_distribution_override() {
         &e.ledger().timestamp().saturating_add(60),
         &rewards
     );
-    router.fill_liquidity(&setup.btc_asset);
-    let pool_tps = router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    let pool_tps = router.config_pool_rewards(&admin, &setup.btc_asset);
 
     // 30 seconds passed, half of the reward is available
     jump(&e, 30);
@@ -598,8 +598,8 @@ fn test_rewards_distribution_override() {
     assert_eq!(router.get_total_accumulated_reward(&setup.btc_asset), pool_tps * 30);
 
     router.config_global_rewards(&admin, &0, &e.ledger().timestamp().saturating_add(10), &rewards);
-    router.fill_liquidity(&setup.btc_asset);
-    router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
 
     // half of the reward accumulated
     assert_eq!(router.get_total_accumulated_reward(&setup.btc_asset), pool_tps * 30);
@@ -652,7 +652,7 @@ fn test_liqidity_not_filled() {
     router.deposit(&user1, &setup.btc_asset, &1000);
     let rewards = Vec::from_array(&e, [setup.btc_asset.clone()]);
     router.config_global_rewards(&admin, &1, &e.ledger().timestamp().saturating_add(60), &rewards);
-    router.config_pool_rewards(&setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
 }
 
 #[test]
@@ -683,8 +683,8 @@ fn test_fill_liqidity_reentrancy() {
     router.deposit(&user1, &setup.btc_asset, &1000);
     let rewards = Vec::from_array(&e, [setup.btc_asset.clone()]);
     router.config_global_rewards(&admin, &1, &e.ledger().timestamp().saturating_add(60), &rewards);
-    router.fill_liquidity(&setup.btc_asset);
-    router.fill_liquidity(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
 }
 
 #[test]
@@ -715,9 +715,9 @@ fn test_config_pool_rewards_reentrancy() {
     router.deposit(&user1, &setup.btc_asset, &1000);
     let rewards = Vec::from_array(&e, [setup.btc_asset.clone()]);
     router.config_global_rewards(&admin, &1, &e.ledger().timestamp().saturating_add(60), &rewards);
-    router.fill_liquidity(&setup.btc_asset);
-    router.config_pool_rewards(&setup.btc_asset);
-    router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
 }
 
 #[test]
@@ -747,13 +747,13 @@ fn test_config_pool_rewards_after_new_global_config() {
     router.deposit(&user1, &setup.btc_asset, &1000);
     let rewards = Vec::from_array(&e, [setup.btc_asset.clone()]);
     router.config_global_rewards(&admin, &1, &e.ledger().timestamp().saturating_add(60), &rewards);
-    router.fill_liquidity(&setup.btc_asset);
-    assert_eq!(router.config_pool_rewards(&setup.btc_asset), 1);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    assert_eq!(router.config_pool_rewards(&admin, &setup.btc_asset), 1);
 
     jump(&e, 300);
     router.config_global_rewards(&admin, &1, &e.ledger().timestamp().saturating_add(60), &rewards);
-    router.fill_liquidity(&setup.btc_asset);
-    assert_eq!(router.config_pool_rewards(&setup.btc_asset), 1);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    assert_eq!(router.config_pool_rewards(&admin, &setup.btc_asset), 1);
 }
 
 #[test]
@@ -791,8 +791,8 @@ fn test_config_pool_after_liquidity_fill() {
         &e.ledger().timestamp().saturating_add(60),
         &rewards
     );
-    router.fill_liquidity(&setup.btc_asset);
-    assert_eq!(router.config_pool_rewards(&tokens, &pool_1_hash), 1_0000000);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    assert_eq!(router.config_pool_rewards(&admin, &tokens, &pool_1_hash), 1_0000000);
 
     let (pool_2_hash, _pool_2_address) = router.init_pool(
         &user1,
@@ -833,7 +833,7 @@ fn test_fill_liquidity_no_config() {
     token2.mint(&user1, &2000);
 
     router.deposit(&user1, &setup.btc_asset, &1000);
-    router.fill_liquidity(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
 }
 
 #[test]
@@ -944,7 +944,7 @@ fn test_config_rewards_no_pools_for_tokens() {
         router.get_tokens_for_reward(),
         Map::from_array(&e, [(tokens.clone(), (1_0000000, false, U256::from_u32(&e, 0)))])
     );
-    router.fill_liquidity(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
     assert_eq!(
         router.get_tokens_for_reward(),
         Map::from_array(&e, [(tokens.clone(), (1_0000000, true, U256::from_u32(&e, 0)))])
@@ -1028,8 +1028,8 @@ fn test_event_correct() {
         &e.ledger().timestamp().saturating_add(60),
         &rewards
     );
-    router.fill_liquidity(&setup.btc_asset);
-    router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
 
     token2.mint(&user1, &1000);
     assert_eq!(token2.balance(&user1), 1000);
@@ -1175,8 +1175,8 @@ fn test_rewards_distribution_without_outstanding_rewards() {
         &rewards
     );
 
-    router.fill_liquidity(&setup.btc_asset);
-    router.config_pool_rewards(&setup.btc_asset);
+    router.fill_liquidity(&admin, &setup.btc_asset);
+    router.config_pool_rewards(&admin, &setup.btc_asset);
 
     // check that we don't need to add rewards to pool
     assert_eq!(router.get_total_outstanding_reward(&setup.btc_asset), 0);

--- a/contracts/pool_router/src/test_permissions.rs
+++ b/contracts/pool_router/src/test_permissions.rs
@@ -532,8 +532,8 @@ fn test_distribute_rewards() {
             &e.ledger().timestamp().saturating_add(60),
             &Vec::from_array(&e, [setup.btc_asset.clone()])
         );
-        router.fill_liquidity(&setup.btc_asset);
-        router.config_pool_rewards(&setup.btc_asset);
+        router.fill_liquidity(&addr, &setup.btc_asset);
+        router.config_pool_rewards(&addr, &setup.btc_asset);
 
         assert_eq!(
             router


### PR DESCRIPTION
This PR does the following:
- Gates fill_liquidity() and config_pool_rewards() with require_auth(rewards_admin) 
- Rejects fill_liquidity() when total_liquidity == 0