### PR TITLE
[Fix(HAL-005)]: sanitize_clamp_denominator is Unchecked (Division-by-Zero Risk)

### DIFF
--- a/contracts/oracle_registry/src/contract.rs
+++ b/contracts/oracle_registry/src/contract.rs
@@ -1,4 +1,5 @@
 use crate::errors::OracleRegistryError;
+use utils::validation::validate_positive_denominator;
 use crate::interface::{ AdminInterface, OracleRegistryTrait };
 use crate::oracle::{ block_operation, get_oracle_price, oracle_validity, update_twap };
 use crate::storage::{
@@ -248,6 +249,7 @@ impl AdminInterface for OracleRegistry {
     // * `OracleInfo` - The successfully registered oracle metadata.
     //
     // # Panics
+    // * `OracleRegistryError::InvalidClampDenominator` if the sanitize_clamp_denominator is negative.
     // * `OracleRegistryError::OracleAlreadyRegistered` if the asset already has an oracle.
     // * `OracleRegistryError::OracleInvalid` if the provided oracle fails validation (e.g. non-positive, too stale, or volatile).
     fn register_oracle(
@@ -257,10 +259,12 @@ impl AdminInterface for OracleRegistry {
         oracle_addr: Address,
         asset_addr: Address,
         decimals: u32,
-        sanitize_clamp_denominator: i64
+        sanitize_clamp_denominator: u64
     ) -> OracleInfo {
         admin.require_auth();
         require_admin(&e, &admin);
+
+        validate_positive_denominator(&e, sanitize_clamp_denominator, OracleRegistryError::InvalidClampDenominator);
 
         if get_oracle_base(&e, &asset).is_some() {
             panic_with_error!(&e, OracleRegistryError::OracleAlreadyRegistered);
@@ -320,6 +324,7 @@ impl AdminInterface for OracleRegistry {
     // # Panics
     // * `OracleRegistryError::OracleInvalid` if the new address returns an invalid price.
     // * `OracleRegistryError::InvalidDecimals` if provided decimals exceed safe limits.
+    // * `OracleRegistryError::InvalidClampDenominator` if the sanitize_clamp_denominator is negative.
     // * `OracleRegistryError::OracleNotRegistered` if the asset does not have a registered oracle.
     fn update_oracle(
         e: Env,
@@ -356,6 +361,10 @@ impl AdminInterface for OracleRegistry {
                 if decimals > 18 {
                     panic_with_error!(&e, OracleRegistryError::InvalidDecimals);
                 }
+            }
+
+            if let Some(sanitize_clamp_denominator) = params.sanitize_clamp_denominator {
+                validate_positive_denominator(&e, sanitize_clamp_denominator, OracleRegistryError::InvalidClampDenominator);
             }
 
             let updated_oracle = OracleInfo {

--- a/contracts/oracle_registry/src/errors.rs
+++ b/contracts/oracle_registry/src/errors.rs
@@ -15,4 +15,5 @@ pub enum OracleRegistryError {
     OracleInvalid = 23,
     PriceOverrideTooSoon = 24,
     OracleAlreadyRegistered = 25,
+    InvalidClampDenominator = 26,
 }

--- a/contracts/oracle_registry/src/interface.rs
+++ b/contracts/oracle_registry/src/interface.rs
@@ -51,7 +51,7 @@ pub trait AdminInterface {
         oracle_addr: Address,
         asset_addr: Address,
         decimals: u32,
-        sanitize_clamp_denominator: i64
+        sanitize_clamp_denominator: u64
     ) -> OracleInfo;
 
     // Update oracle info

--- a/contracts/oracle_registry/src/oracle.rs
+++ b/contracts/oracle_registry/src/oracle.rs
@@ -62,7 +62,7 @@ pub fn update_twap(
     asset: &Symbol,
     historical_oracle_data: &HistoricalOracleData,
     oracle_price_data: &OraclePriceData,
-    sanitize_clamp_denominator: i64,
+    sanitize_clamp_denominator: u64,
     now: u64,
     registering: bool
 ) {

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -51,7 +51,7 @@ pub const PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128: i128 =
 
 // Pool
 pub const FEE_MULTIPLIER: u128 = 10_000;
-pub const DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR: i64 = 3; // '3' here means clamp new data point to 33% (1/3) divergence from current twap (if twap > 0)
+pub const DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR: u64 = 3; // '3' here means clamp new data point to 33% (1/3) divergence from current twap (if twap > 0)
 
 // Pool Router
 pub const MAX_POOL_FEE: u32 = 100; // 1%

--- a/modules/utils/src/lib.rs
+++ b/modules/utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod state;
 pub mod token;
 pub mod errors;
 pub mod math;
+pub mod validation;
 
 pub mod test;
 #[cfg(any(test, feature = "testutils"))]

--- a/modules/utils/src/math/pool.rs
+++ b/modules/utils/src/math/pool.rs
@@ -8,7 +8,7 @@ pub fn sanitize_new_price(
     e: &Env,
     new_price: u128,
     last_price_twap: u128,
-    sanitize_clamp_denominator: i64
+    sanitize_clamp_denominator: u64
 ) -> u128 {
     // when/if twap is 0, dont try to normalize new_price
     if last_price_twap == 0 {

--- a/modules/utils/src/state/oracle_registry.rs
+++ b/modules/utils/src/state/oracle_registry.rs
@@ -22,7 +22,7 @@ pub struct OracleInfo {
     pub asset_addr: Address,
     pub decimals: u32,
     pub frozen: bool,
-    pub sanitize_clamp_denominator: i64, // zero if not set
+    pub sanitize_clamp_denominator: u64, // zero if not set
     pub last_updated: u64,
 }
 
@@ -32,7 +32,7 @@ pub struct MutableOracleInfo {
     pub address: Option<Address>,
     pub decimals: Option<u32>,
     pub frozen: Option<bool>,
-    pub sanitize_clamp_denominator: Option<i64>,
+    pub sanitize_clamp_denominator: Option<u64>,
 }
 
 impl MutableOracleInfo {

--- a/modules/utils/src/validation.rs
+++ b/modules/utils/src/validation.rs
@@ -1,0 +1,23 @@
+use soroban_sdk::{Env, panic_with_error};
+
+/// Validates that a denominator value is positive (greater than 0).
+/// 
+/// This prevents negative values from being cast to unsigned integers in division operations,
+/// which would create extremely large denominators and cause division results to approach zero.
+/// 
+/// # Arguments
+/// * `e` - The Soroban environment
+/// * `value` - The denominator value to validate
+/// * `error` - The error to panic with if validation fails
+/// 
+/// # Panics
+/// Panics with the provided error if the value is negative.
+/// Note: Zero values are allowed as they are typically handled separately with default fallbacks.
+pub fn validate_positive_denominator<E>(e: &Env, value: u64, error: E) 
+where
+    E: Into<soroban_sdk::Error>,
+{
+    if value <= 0 {
+        panic_with_error!(e, error);
+    }
+}


### PR DESCRIPTION
feat: check util for negative denominators - avoids twap clamps

Ft: types change cherrypicked from reference commit

fix: validation util in sync with prev type change
