### PR TITLE
[Fix(HAL-003)]: Stale-delay Allows Frozen or Cached Prices to Look Fresh

### DIFF
--- a/contracts/oracle_registry/src/contract.rs
+++ b/contracts/oracle_registry/src/contract.rs
@@ -26,6 +26,7 @@ use upgrade::events::Events as UpgradeEvents;
 use upgrade::interface::UpgradeableContract;
 use upgrade::{ apply_upgrade, commit_upgrade, revert_upgrade };
 use utils::state::oracle_registry::{ MutableOracleInfo, NormalAction, OracleInfo, OraclePriceData };
+use utils::temporal::Delay;
 
 #[contract]
 pub struct OracleRegistry;
@@ -78,7 +79,11 @@ impl OracleRegistryTrait for OracleRegistry {
         if cached || oracle.frozen {
             return OraclePriceData {
                 price: historical_oracle_data.last_oracle_price_twap,
-                delay: historical_oracle_data.last_oracle_delay,
+                delay: Delay::from_timestamp_diff_expect(
+                    now, 
+                    historical_oracle_data.last_oracle_price_twap_ts,
+                    "Historical oracle timestamp cannot be in the future"
+                ),
             };
         }
 
@@ -416,7 +421,11 @@ impl AdminInterface for OracleRegistry {
                 historical_oracle_data.last_oracle_price_twap,
                 &(OraclePriceData {
                     price,
-                    delay: now - historical_oracle_data.last_oracle_price_twap_ts,
+                    delay: Delay::from_timestamp_diff_expect(
+                        now,
+                        historical_oracle_data.last_oracle_price_twap_ts,
+                        "Historical TWAP timestamp cannot be in the future"
+                    ),
                 })
             ) == OracleValidity::Valid;
 
@@ -435,7 +444,7 @@ impl AdminInterface for OracleRegistry {
             &e,
             &asset,
             &historical_oracle_data,
-            &(OraclePriceData { price: price, delay: 0 }),
+            &(OraclePriceData { price: price, delay: Delay::ZERO }),
             oracle.sanitize_clamp_denominator,
             now,
             false

--- a/contracts/oracle_registry/src/oracle.rs
+++ b/contracts/oracle_registry/src/oracle.rs
@@ -4,6 +4,7 @@ use utils::{
     constant::{ FIVE_MINUTE, PERCENTAGE_PRECISION_U64, PRICE_PRECISION_U64 },
     math::{ pool::sanitize_new_price, safe_math::SafeMath, stats::calculate_new_twap },
     state::oracle_registry::{ NormalAction, OraclePriceData },
+    temporal::Delay,
 };
 
 use crate::{
@@ -36,7 +37,11 @@ pub fn get_oracle_price(e: &Env, oracle: &Address, asset: &Address, now: u64) ->
     oracle_price = oracle_price_data.price as u128;
     published_ts = oracle_price_data.timestamp;
 
-    let oracle_delay = now.safe_sub(e, published_ts);
+    let oracle_delay = Delay::from_timestamp_diff_expect(
+        now, 
+        published_ts,
+        "Oracle published timestamp cannot be in the future"
+    );
 
     OraclePriceData {
         price: oracle_price,
@@ -89,7 +94,7 @@ pub fn update_twap(
             oracle_price_twap
         },
         last_oracle_price: oracle_price_data.price,
-        last_oracle_delay: oracle_price_data.delay,
+        last_oracle_delay: oracle_price_data.delay.as_seconds(),
         last_oracle_price_twap_ts: now,
     };
     put_historical_oracle_data(e, &asset, &new_historical_oracle_data);

--- a/contracts/oracle_registry/src/storage_types.rs
+++ b/contracts/oracle_registry/src/storage_types.rs
@@ -36,7 +36,7 @@ impl HistoricalOracleData {
     pub fn default_with_current_oracle(oracle_price_data: OraclePriceData) -> Self {
         HistoricalOracleData {
             last_oracle_price: oracle_price_data.price,
-            last_oracle_delay: oracle_price_data.delay,
+            last_oracle_delay: oracle_price_data.delay.as_seconds(),
             last_oracle_price_twap: oracle_price_data.price,
             ..HistoricalOracleData::default()
         }

--- a/contracts/oracle_registry/src/test.rs
+++ b/contracts/oracle_registry/src/test.rs
@@ -35,7 +35,7 @@ fn test_get_price() {
     let oracle_price_data = setup.registry.get_price(&setup.btc_asset_id, &false);
 
     assert_eq!(oracle_price_data.price, new_oracle_price as u128);
-    assert_eq!(oracle_price_data.delay, 0);
+    assert_eq!(oracle_price_data.delay.as_seconds(), 0);
 
     // Ensure historical data is updated
     // let last_price_info = setup.registry.get_last_price(&setup.btc_asset_id);
@@ -61,7 +61,7 @@ fn test_get_price() {
 
 //     // TODO: price should come from historical oracle data
 //     assert_eq!(oracle_price_data.price, 100);
-//     assert_eq!(oracle_price_data.delay, 0);
+//     assert_eq!(oracle_price_data.delay.as_seconds(), 0);
 // }
 
 // #[test]
@@ -70,7 +70,7 @@ fn test_get_price() {
 //     let oracle_price_data = setup.registry.get_price(&setup.asset_id, &false);
 //     // TODO: price should come from historical oracle data
 //     assert_eq!(oracle_price_data.price, 100);
-//     assert_eq!(oracle_price_data.delay, 0);
+//     assert_eq!(oracle_price_data.delay.as_seconds(), 0);
 // }
 
 // #[test]

--- a/modules/utils/src/lib.rs
+++ b/modules/utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod constant;
 pub mod helpers;
 pub mod macros;
 pub mod state;
+pub mod temporal;
 pub mod token;
 pub mod errors;
 pub mod math;

--- a/modules/utils/src/state/oracle_registry.rs
+++ b/modules/utils/src/state/oracle_registry.rs
@@ -1,10 +1,11 @@
 use soroban_sdk::{ contracttype, Address };
+use crate::temporal::Delay;
 
 #[contracttype]
 #[derive(Default, Clone, Copy, Debug)]
 pub struct OraclePriceData {
     pub price: u128,
-    pub delay: u64,
+    pub delay: Delay,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]

--- a/modules/utils/src/temporal.rs
+++ b/modules/utils/src/temporal.rs
@@ -1,0 +1,54 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct Delay(u64);
+
+impl Delay {
+    
+    pub const fn from_seconds(seconds: u64) -> Self {
+        Self(seconds)
+    }
+    
+    pub const fn as_seconds(self) -> u64 {
+        self.0
+    }
+    
+    pub fn from_timestamp_diff(now: u64, past_timestamp: u64) -> Option<Self> {
+        now.checked_sub(past_timestamp).map(Self)
+    }
+       
+    pub fn from_timestamp_diff_expect(now: u64, past_timestamp: u64, msg: &str) -> Self {
+        Self::from_timestamp_diff(now, past_timestamp)
+            .unwrap_or_else(|| panic!("{}", msg))
+    }
+     
+    pub const ZERO: Self = Self(0);
+}
+
+
+impl PartialEq<u64> for Delay {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialOrd<u64> for Delay {
+    fn partial_cmp(&self, other: &u64) -> Option<core::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+
+impl From<u64> for Delay {
+    fn from(seconds: u64) -> Self {
+        Self::from_seconds(seconds)
+    }
+}
+
+
+impl From<Delay> for u64 {
+    fn from(delay: Delay) -> Self {
+        delay.as_seconds()
+    }
+}


### PR DESCRIPTION
[Critical Fix]: Compute delay instead of using a stored one

Feat: temporal type (delay) implementation
