### PR TITLE
refactor(Insurance Fund): Multi-token support

### DIFF
--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -2,6 +2,7 @@ use crate::errors::InsuranceFundError;
 use crate::events::Events as FundEvents;
 use crate::events::InsuranceFundEvents;
 use crate::interest::calculate_rate;
+use crate::interest::calculate_total_reserve_value;
 use crate::interest::calculate_utilization;
 use crate::interface::{AdminInterface, InsuranceFundTrait};
 use crate::reserve::InsuranceFundReserve;
@@ -13,23 +14,27 @@ use crate::stake::{
 use crate::storage::get_contract_token_balance;
 use crate::storage::get_deletion_queue;
 use crate::storage::get_pool_router;
+use crate::storage::get_oracle_registry;
 use crate::storage::get_premium_token;
 use crate::storage::get_premium_whitelist_status;
 use crate::storage::get_reserve;
-use crate::storage::get_whitelist_tokens;
+use crate::storage::get_token_whitelist_status;
 use crate::storage::put_reserve;
 use crate::storage::set_oracle_registry;
 use crate::storage::set_pool_router;
 use crate::storage::set_premium_token;
-use crate::storage::set_whitelist_tokens;
-use crate::storage::validate_whitelisted_token;
 use crate::storage::{
-    get_base_rate, get_insurance_vault_amount, get_is_killed_deposit,
+    get_base_rate, get_is_killed_deposit,
     get_is_killed_request_withdraw, get_is_killed_withdraw, get_optimal_insurance,
     get_optimal_utilization, get_rate_slope_a, get_rate_slope_b, get_unstaking_period,
     set_base_rate, set_is_killed_deposit, set_is_killed_request_withdraw, set_is_killed_withdraw,
     set_optimal_insurance, set_optimal_utilization, set_rate_slope_a, set_rate_slope_b,
     set_unstaking_period,
+    get_base_rate, get_is_killed_deposit, get_is_killed_request_withdraw, get_is_killed_withdraw,
+    get_optimal_insurance, get_optimal_utilization, get_rate_slope_a, get_rate_slope_b,
+    get_unstaking_period, set_base_rate, set_is_killed_deposit, set_is_killed_request_withdraw,
+    set_is_killed_withdraw, set_optimal_insurance, set_optimal_utilization, set_rate_slope_a,
+    set_rate_slope_b, set_unstaking_period,
 };
 use reentrancy_guard::{enter, exit};
 
@@ -51,6 +56,7 @@ use upgrade::interface::UpgradeableContract;
 use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
 use utils::math::safe_math::SafeMath;
 use utils::state::pool::PoolInfo;
+use utils::state::token::DetailedToken;
 use utils::token::transfer_token;
 use utils::token::validate_token_contract;
 use utils::token::validate_token_contracts;
@@ -77,6 +83,7 @@ impl InsuranceFundTrait for InsuranceFund {
         pool_router: Address,
         premium_token: Address,
         whitelisted_tokens: Vec<Address>,
+        oracle_registry: Address,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -102,6 +109,7 @@ impl InsuranceFundTrait for InsuranceFund {
             put_reserve(&e, &token, &reserve);
         }
 
+        set_oracle_registry(&e, &oracle_registry);
         set_premium_token(&e, &premium_token);
         set_whitelist_tokens(&e, &whitelisted_tokens);
         set_unstaking_period(&e, &unstaking_period);
@@ -159,15 +167,17 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundDepositKilled);
         }
 
-        validate_whitelisted_token(&e, &token);
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
 
         let optimal_insurance = get_optimal_insurance(&e);
-        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
+        let reserve = get_reserve(&e, &token);
 
         // Ensure the new stake will not exceed the optimal insurance
         validate!(
             e,
-            insurance_vault_amount + amount <= optimal_insurance,
+            reserve.balance + amount <= optimal_insurance,
             InsuranceFundError::TooMuchInsurance
         );
 
@@ -181,7 +191,7 @@ impl InsuranceFundTrait for InsuranceFund {
         );
 
         // Rebase Insurance Fund and Stake
-        apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
+        apply_rebase_to_insurance_fund(&e, &token);
         apply_rebase_to_stake(&e, &mut stake);
 
         // Get updated Reserve after rebase
@@ -190,7 +200,7 @@ impl InsuranceFundTrait for InsuranceFund {
         let if_shares_before = stake.checked_if_shares(&e);
         let total_if_shares_before = reserve.total_shares;
 
-        let n_shares = reserve_amount_to_shares(&e, amount, reserve);
+        let n_shares = reserve_amount_to_shares(&e, amount, &reserve);
 
         // reset cost basis if no shares
         stake.cost_basis = if if_shares_before == 0 {
@@ -212,14 +222,14 @@ impl InsuranceFundTrait for InsuranceFund {
             token.clone(),
             StakeAction::Deposit,
             amount,
-            insurance_vault_amount,
+            reserve.balance,
             if_shares_before,
             total_if_shares_before,
             if_shares_after,
             new_total_shares,
         );
 
-        save_stake(&e, &user, &stake);
+        save_stake(&e, &user, &token, &stake);
 
         transfer_token(
             &e,
@@ -276,10 +286,12 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundRequestWithdrawKilled);
         }
 
-        validate_whitelisted_token(&e, &token);
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
 
         let now = e.ledger().timestamp();
-        let mut stake = get_stake(&e, &user);
+        let mut stake = get_stake(&e, &user, &token);
 
         // Error if a withdraw request is already in progress
         validate!(
@@ -289,9 +301,8 @@ impl InsuranceFundTrait for InsuranceFund {
         );
 
         // Convert token amount to # of shares
-        let total_shares = get_total_shares(&e);
         let reserve = get_reserve(&e, &token);
-        let n_shares = reserve_amount_to_shares(&e, amount, reserve);
+        let n_shares = reserve_amount_to_shares(&e, amount, &reserve);
 
         validate!(
             &e,
@@ -310,33 +321,35 @@ impl InsuranceFundTrait for InsuranceFund {
         // Update the user stake
         stake.last_withdraw_request_shares = n_shares;
 
-        apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
+        apply_rebase_to_insurance_fund(&e, &token);
         apply_rebase_to_stake(&e, &mut stake);
 
-        let reserve = get_reserve(&e, &token);
+        // Get post rebase values
+        let reserve_after_rebase = get_reserve(&e, &token);
+        let stake_after_rebase = get_stake(&e, &user, &token);
 
-        let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = reserve.total_shares;
+        let if_shares_before = stake_after_rebase.checked_if_shares(&e);
+        let total_if_shares_before = reserve_after_rebase.total_shares;
 
-        // "last_withdraw_request_shares exceeds if_shares {} > {}",
         validate!(
             &e,
             stake.last_withdraw_request_shares <= stake.checked_if_shares(&e),
             InsuranceFundError::InvalidInsuranceUnstakeSize
         );
 
-        // "if stake base != base"
         validate!(
             &e,
-            stake.if_base == shares_base,
+            stake.if_base == reserve_after_rebase.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        stake.last_withdraw_request_value =
-            shares_to_reserve_amount(&e, stake.last_withdraw_request_shares, reserve)
-                .min(reserve.balance.saturating_sub(1));
+        stake.last_withdraw_request_value = shares_to_reserve_amount(
+            &e,
+            stake.last_withdraw_request_shares,
+            &reserve_after_rebase,
+        )
+        .min(reserve_after_rebase.balance.saturating_sub(1));
 
-        //  "Requested withdraw value is not below Insurance Fund balance"
         validate!(
             &e,
             stake.last_withdraw_request_value == 0
@@ -355,12 +368,12 @@ impl InsuranceFundTrait for InsuranceFund {
             if_shares_before,
             total_if_shares_before,
             if_shares_after,
-            total_shares,
+            reserve_after_rebase.total_shares,
         );
 
         stake.last_withdraw_request_ts = now;
 
-        save_stake(&e, &user, &stake);
+        save_stake(&e, &user, &token, &stake);
 
         exit(&e);
     }
@@ -396,8 +409,12 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
+
         let now = e.ledger().timestamp();
-        let mut stake = get_stake(&e, &user);
+        let mut stake = get_stake(&e, &user, &token);
 
         //  "No withdraw request in progress"
         validate!(
@@ -408,7 +425,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         let reserve = get_reserve(&e, &token);
 
-        apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
+        apply_rebase_to_insurance_fund(&e, &token);
         apply_rebase_to_stake(&e, &mut stake);
 
         let reserve_after_rebase = get_reserve(&e, &token);
@@ -452,7 +469,7 @@ impl InsuranceFundTrait for InsuranceFund {
         stake.last_withdraw_request_value = 0;
         stake.last_withdraw_request_ts = now;
 
-        save_stake(&e, &user, &stake);
+        save_stake(&e, &user, &token, &stake);
 
         exit(&e);
     }
@@ -499,11 +516,15 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundWithdrawKilled);
         }
 
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
+
         // TODO: Do we need to check IF utilization and/or overall pool liquidity imbalance for edge
         // cases before authorizing a withdrawal?
 
         let now = e.ledger().timestamp();
-        let mut stake = get_stake(&e, &user);
+        let mut stake = get_stake(&e, &user, &token);
 
         // Add bounds checking to prevent underflow when system clock goes backwards
         validate!(
@@ -522,13 +543,14 @@ impl InsuranceFundTrait for InsuranceFund {
 
         let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
 
-        apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
+        apply_rebase_to_insurance_fund(&e, &token);
         apply_rebase_to_stake(&e, &mut stake);
 
-        let total_shares = get_total_shares(&e);
+        // let total_shares = get_total_shares(&e);
+        let reserve_after_rebase = get_reserve(&e, &token);
 
         let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = total_shares;
+        let total_if_shares_before = reserve_after_rebase.total_shares;
 
         let n_shares = stake.last_withdraw_request_shares;
 
@@ -541,9 +563,9 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::InsufficientIFShares
         );
 
-        let amount = shares_to_reserve_amount(&e, n_shares, total_shares, insurance_vault_amount);
+        let amount = shares_to_reserve_amount(&e, n_shares, &reserve_after_rebase);
 
-        let _if_shares_lost = calculate_shares_lost(&e, &stake, insurance_vault_amount);
+        let _if_shares_lost = calculate_shares_lost(&e, &stake, &reserve_after_rebase);
 
         let withdraw_amount = amount.min(stake.last_withdraw_request_value);
 
@@ -560,7 +582,7 @@ impl InsuranceFundTrait for InsuranceFund {
         // Add bounds checking to prevent critical share tracking underflow
         validate!(
             &e,
-            total_shares >= n_shares,
+            reserve_after_rebase.total_shares >= n_shares,
             InsuranceFundError::InsufficientIFShares
         );
         set_total_shares(&e, &(total_shares - n_shares));
@@ -581,10 +603,10 @@ impl InsuranceFundTrait for InsuranceFund {
             if_shares_before,
             total_if_shares_before,
             if_shares_after,
-            total_shares,
+            reserve_after_rebase.total_shares,
         );
 
-        save_stake(&e, &user, &stake);
+        save_stake(&e, &user, &token, &stake);
 
         transfer_token(
             &e,
@@ -594,11 +616,11 @@ impl InsuranceFundTrait for InsuranceFund {
             &(withdraw_amount as i128),
         );
 
-        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
+        let new_reserve = get_reserve(&e, &token);
 
         validate!(
             &e,
-            insurance_vault_amount > 0,
+            new_reserve.balance > 0,
             InsuranceFundError::InvalidIFDetected
         );
 
@@ -669,7 +691,9 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        validate_token_contract(&e, &token);
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
 
         let now = e.ledger().timestamp();
         let reserve = get_reserve(&e, &token);
@@ -691,7 +715,9 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        validate_token_contract(&e, &token);
+        if !get_token_whitelist_status(&e, &token) {
+            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
+        }
 
         let reserve = get_reserve(&e, &token);
         let balance = get_contract_token_balance(&e, &token);
@@ -732,16 +758,12 @@ impl InsuranceFundTrait for InsuranceFund {
         get_optimal_insurance(&e)
     }
 
-    fn get_total_shares(e: Env) -> u128 {
-        get_total_shares(&e)
+    fn get_reserve(e: Env, token: Address) -> InsuranceFundReserve {
+        get_reserve(&e, &token)
     }
 
-    fn get_share_base(e: Env) -> u128 {
-        get_shares_base(&e)
-    }
-
-    fn get_stake(e: Env, user: Address) -> Stake {
-        get_stake(&e, &user)
+    fn get_stake(e: Env, user: Address, token: Address) -> Stake {
+        get_stake(&e, &user, &token)
     }
 
     fn get_optimal_utilization(e: Env) -> u32 {
@@ -755,9 +777,10 @@ impl InsuranceFundTrait for InsuranceFund {
     //
     // The utilization rate as a u32.
     fn get_utilization(e: Env) -> u32 {
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
+        let total_reserve_value = calculate_total_reserve_value(&e);
         let optimal_insurance = get_optimal_insurance(&e);
-        calculate_utilization(insurance_vault_amount, optimal_insurance)
+
+        calculate_utilization(total_reserve_value, optimal_insurance)
     }
 
     // Get the current staking interest rate.
@@ -770,9 +793,9 @@ impl InsuranceFundTrait for InsuranceFund {
         let optimal_utilization = get_optimal_utilization(&e);
         let base_rate = get_base_rate(&e);
 
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
+        let total_reserve_value = calculate_total_reserve_value(&e);
         let optimal_insurance = get_optimal_insurance(&e);
-        let utilization = calculate_utilization(insurance_vault_amount, optimal_insurance);
+        let utilization = calculate_utilization(total_reserve_value, optimal_insurance);
 
         let (slope1, slope2) = (get_rate_slope_a(&e), get_rate_slope_b(&e));
 
@@ -995,7 +1018,7 @@ impl AdminInterface for InsuranceFund {
                 panic_with_error!(&e, InsuranceFundError::QueryPoolFailed);
             }
             Ok(Ok(pool_info)) => {
-                let insurance_vault_amount = get_insurance_vault_amount(&e);
+                let reserve = get_reserve(&e, &token);
 
                 // Call `Pool.pay_insurance_claim()` to calculate how much insurance is needed
                 // and to update the `Pool.insurance_claim`
@@ -1006,7 +1029,7 @@ impl AdminInterface for InsuranceFund {
                         &e,
                         [
                             e.current_contract_address().to_val(),
-                            insurance_vault_amount.into_val(&e),
+                            reserve.balance.into_val(&e),
                         ],
                     ),
                 );
@@ -1058,23 +1081,30 @@ impl AdminInterface for InsuranceFund {
         set_pool_router(&e, &pool_router);
     }
 
-    fn add_whitelist_token(e: Env, admin: Address, token: Address) {
+    fn add_whitelist_token(e: Env, admin: Address, token: DetailedToken) {
         admin.require_auth();
         require_admin(&e, &admin);
 
-        validate_token_contract(&e, &token);
+        validate_token_contract(&e, &token.address);
+
+        // Validate oracle
+        e.invoke_contract(
+            &get_oracle_registry(&e),
+            &Symbol::new(&e, "get_price"),
+            Vec::from_array(&e, [token.symbol.to_val()]),
+        );
 
         let whitelist = get_whitelist_tokens(&e);
         let deletion_queue = get_deletion_queue(&e);
 
-        if deletion_queue.contains(&token) {}
+        if deletion_queue.contains(&token.address) {}
 
-        if whitelist.contains(&token) {}
+        if whitelist.contains(&token.address) {}
 
         FundEvents::new(&e).whitelist_token(admin, token);
     }
 
-    fn remove_whitelist_token(e: Env, admin: Address, token: Address) {
+    fn remove_whitelist_token(e: Env, admin: Address, token: DetailedToken) {
         admin.require_auth();
         require_admin(&e, &admin);
 

--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -10,6 +10,7 @@ use crate::stake::{
     apply_rebase_to_insurance_fund, apply_rebase_to_stake, calculate_shares_lost, get_stake,
     reserve_amount_to_shares, save_stake, shares_to_reserve_amount, StakeAction,
 };
+use crate::storage::get_contract_token_balance;
 use crate::storage::get_deletion_queue;
 use crate::storage::get_pool_router;
 use crate::storage::get_premium_token;
@@ -653,6 +654,52 @@ impl InsuranceFundTrait for InsuranceFund {
         );
 
         FundEvents::new(&e).collect_premium(sender, premium_token, amount);
+
+        exit(&e);
+    }
+
+    // Sync token balances with reserves.
+    //
+    // # Arguments
+    //
+    // * `sender` - The address of the sender.
+    // * `token` - The address of the token to sync.
+    fn sync(e: Env, sender: Address, token: Address) {
+        sender.require_auth();
+
+        enter(&e);
+
+        validate_token_contract(&e, &token);
+
+        let now = e.ledger().timestamp();
+        let reserve = get_reserve(&e, &token);
+        let balance = get_contract_token_balance(&e, &token);
+        put_reserve(&e, &token, &reserve.update_balance(balance, now));
+        FundEvents::new(&e).sync(sender, token, 0);
+
+        exit(&e);
+    }
+
+    // Skim excess token balances.
+    //
+    // # Arguments
+    //
+    // * `sender` - The address of the sender.
+    // * `token` - The address of the token to skim.
+    fn skim(e: Env, sender: Address, token: Address) {
+        sender.require_auth();
+
+        enter(&e);
+
+        validate_token_contract(&e, &token);
+
+        let reserve = get_reserve(&e, &token);
+        let balance = get_contract_token_balance(&e, &token);
+        let skimmed = balance.saturating_sub(reserve.balance) as i128;
+        if skimmed > 0 {
+            transfer_token(&e, &token, &e.current_contract_address(), &sender, &skimmed);
+            FundEvents::new(&e).skim(sender, token, skimmed);
+        }
 
         exit(&e);
     }

--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -4,21 +4,30 @@ use crate::events::InsuranceFundEvents;
 use crate::interest::calculate_rate;
 use crate::interest::calculate_utilization;
 use crate::interface::{AdminInterface, InsuranceFundTrait};
+use crate::reserve::InsuranceFundReserve;
 use crate::stake::Stake;
 use crate::stake::{
-    apply_rebase_to_insurance_fund, apply_rebase_to_stake, calculate_if_shares_lost, get_stake,
-    if_shares_to_vault_amount, save_stake, vault_amount_to_if_shares, StakeAction,
+    apply_rebase_to_insurance_fund, apply_rebase_to_stake, calculate_shares_lost, get_stake,
+    reserve_amount_to_shares, save_stake, shares_to_reserve_amount, StakeAction,
 };
+use crate::storage::get_deletion_queue;
 use crate::storage::get_pool_router;
+use crate::storage::get_premium_token;
 use crate::storage::get_premium_whitelist_status;
+use crate::storage::get_reserve;
+use crate::storage::get_whitelist_tokens;
+use crate::storage::put_reserve;
+use crate::storage::set_oracle_registry;
 use crate::storage::set_pool_router;
+use crate::storage::set_premium_token;
+use crate::storage::set_whitelist_tokens;
+use crate::storage::validate_whitelisted_token;
 use crate::storage::{
     get_base_rate, get_insurance_vault_amount, get_is_killed_deposit,
     get_is_killed_request_withdraw, get_is_killed_withdraw, get_optimal_insurance,
-    get_optimal_utilization, get_rate_slope_a, get_rate_slope_b, get_shares_base, get_token,
-    get_total_shares, get_unstaking_period, set_base_rate, set_is_killed_deposit,
-    set_is_killed_request_withdraw, set_is_killed_withdraw, set_optimal_insurance,
-    set_optimal_utilization, set_rate_slope_a, set_rate_slope_b, set_token, set_total_shares,
+    get_optimal_utilization, get_rate_slope_a, get_rate_slope_b, get_unstaking_period,
+    set_base_rate, set_is_killed_deposit, set_is_killed_request_withdraw, set_is_killed_withdraw,
+    set_optimal_insurance, set_optimal_utilization, set_rate_slope_a, set_rate_slope_b,
     set_unstaking_period,
 };
 use reentrancy_guard::{enter, exit};
@@ -42,6 +51,8 @@ use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
 use utils::math::safe_math::SafeMath;
 use utils::state::pool::PoolInfo;
 use utils::token::transfer_token;
+use utils::token::validate_token_contract;
+use utils::token::validate_token_contracts;
 use utils::validate;
 use utils::validation::ensure_non_zero_u128;
 use utils::validation::validate_percentages;
@@ -61,8 +72,10 @@ impl InsuranceFundTrait for InsuranceFund {
         e: Env,
         admin: Address,
         emergency_admin: Address,
-        token: Address,
+        oracle_registry: Address,
         pool_router: Address,
+        premium_token: Address,
+        whitelisted_tokens: Vec<Address>,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -77,8 +90,19 @@ impl InsuranceFundTrait for InsuranceFund {
         access_control.set_role_address(&Role::Admin, &admin);
         access_control.set_role_address(&Role::EmergencyAdmin, &emergency_admin);
 
-        set_token(&e, &token);
+        set_oracle_registry(&e, &token);
         set_pool_router(&e, &pool_router);
+        validate_token_contract(&e, &premium_token);
+        validate_token_contracts(&e, &whitelisted_tokens);
+
+        for i in 0..whitelisted_tokens.len() {
+            let token = whitelisted_tokens.get(i).unwrap();
+            let reserve = get_reserve(&e, &token);
+            put_reserve(&e, &token, &reserve);
+        }
+
+        set_premium_token(&e, &premium_token);
+        set_whitelist_tokens(&e, &whitelisted_tokens);
         set_unstaking_period(&e, &unstaking_period);
         set_optimal_utilization(&e, &optimal_utilization);
         set_base_rate(&e, &base_rate);
@@ -102,6 +126,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // # Arguments
     // * `e` - The Soroban environment.
     // * `user` - The address of the user making the deposit.
+    // * `token` -
     // * `amount` - The number of tokens to deposit into the fund.
     //
     // # Behavior
@@ -122,7 +147,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // * If deposits are currently disabled (`FundDepositKilled`).
     // * If user has a pending withdrawal request.
     // * If the deposit exceeds the configured optimal insurance capacity.
-    fn deposit(e: Env, user: Address, amount: u128) {
+    fn deposit(e: Env, user: Address, token: Address, amount: u128) {
         user.require_auth();
 
         ensure_non_zero_u128(&e, amount);
@@ -133,8 +158,10 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundDepositKilled);
         }
 
+        validate_whitelisted_token(&e, &token);
+
         let optimal_insurance = get_optimal_insurance(&e);
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
+        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
 
         // Ensure the new stake will not exceed the optimal insurance
         validate!(
@@ -143,7 +170,7 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::TooMuchInsurance
         );
 
-        let mut stake = get_stake(&e, &user);
+        let mut stake = get_stake(&e, &user, &token);
 
         // Error if a withdrawal request is in progress
         validate!(
@@ -156,13 +183,13 @@ impl InsuranceFundTrait for InsuranceFund {
         apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
         apply_rebase_to_stake(&e, &mut stake);
 
-        // Get updated total shares after rebase
-        let total_shares = get_total_shares(&e);
+        // Get updated Reserve after rebase
+        let reserve = get_reserve(&e, &token);
 
         let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = total_shares;
+        let total_if_shares_before = reserve.total_shares;
 
-        let n_shares = vault_amount_to_if_shares(&e, amount, total_shares, insurance_vault_amount);
+        let n_shares = reserve_amount_to_shares(&e, amount, reserve);
 
         // reset cost basis if no shares
         stake.cost_basis = if if_shares_before == 0 {
@@ -173,7 +200,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         stake.increase_if_shares(&e, n_shares);
 
-        set_total_shares(&e, &(total_shares + n_shares));
+        set_total_shares(&e, &(reserve.total_shares + n_shares));
 
         let if_shares_after = stake.checked_if_shares(&e);
 
@@ -181,6 +208,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         FundEvents::new(&e).if_stake_record(
             user.clone(),
+            token.clone(),
             StakeAction::Deposit,
             amount,
             insurance_vault_amount,
@@ -194,7 +222,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         transfer_token(
             &e,
-            &get_token(&e),
+            &token,
             &user,
             &e.current_contract_address(),
             &(amount as i128),
@@ -211,6 +239,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // # Arguments
     // * `e` - The Soroban environment.
     // * `user` - The address of the user making the withdrawal request.
+    // * `token` -
     // * `amount` - The token-denominated amount the user wishes to withdraw.
     //
     // # Behavior
@@ -235,7 +264,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // * If the user has insufficient shares to cover the request.
     // * If rebase information is inconsistent or invalid (e.g., mismatched base).
     // * If calculated withdrawal value exceeds the vault balance.
-    fn request_withdraw(e: Env, user: Address, amount: u128) {
+    fn request_withdraw(e: Env, user: Address, token: Address, amount: u128) {
         user.require_auth();
 
         ensure_non_zero_u128(&e, amount);
@@ -245,6 +274,8 @@ impl InsuranceFundTrait for InsuranceFund {
         if get_is_killed_request_withdraw(&e) {
             panic_with_error!(e, InsuranceFundError::FundRequestWithdrawKilled);
         }
+
+        validate_whitelisted_token(&e, &token);
 
         let now = e.ledger().timestamp();
         let mut stake = get_stake(&e, &user);
@@ -258,8 +289,8 @@ impl InsuranceFundTrait for InsuranceFund {
 
         // Convert token amount to # of shares
         let total_shares = get_total_shares(&e);
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
-        let n_shares = vault_amount_to_if_shares(&e, amount, total_shares, insurance_vault_amount);
+        let reserve = get_reserve(&e, &token);
+        let n_shares = reserve_amount_to_shares(&e, amount, reserve);
 
         validate!(
             &e,
@@ -281,11 +312,10 @@ impl InsuranceFundTrait for InsuranceFund {
         apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
         apply_rebase_to_stake(&e, &mut stake);
 
-        let total_shares = get_total_shares(&e);
-        let shares_base = get_shares_base(&e);
+        let reserve = get_reserve(&e, &token);
 
         let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = total_shares;
+        let total_if_shares_before = reserve.total_shares;
 
         // "last_withdraw_request_shares exceeds if_shares {} > {}",
         validate!(
@@ -301,19 +331,15 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::InvalidIFRebase
         );
 
-        stake.last_withdraw_request_value = if_shares_to_vault_amount(
-            &e,
-            stake.last_withdraw_request_shares,
-            total_shares,
-            insurance_vault_amount,
-        )
-        .min(insurance_vault_amount.saturating_sub(1));
+        stake.last_withdraw_request_value =
+            shares_to_reserve_amount(&e, stake.last_withdraw_request_shares, reserve)
+                .min(reserve.balance.saturating_sub(1));
 
         //  "Requested withdraw value is not below Insurance Fund balance"
         validate!(
             &e,
             stake.last_withdraw_request_value == 0
-                || stake.last_withdraw_request_value < insurance_vault_amount,
+                || stake.last_withdraw_request_value < reserve.balance,
             InsuranceFundError::InvalidIFUnstakeSize
         );
 
@@ -321,9 +347,10 @@ impl InsuranceFundTrait for InsuranceFund {
 
         FundEvents::new(&e).if_stake_record(
             user.clone(),
+            token.clone(),
             StakeAction::WithdrawRequest,
             stake.last_withdraw_request_value,
-            insurance_vault_amount,
+            reserve.balance,
             if_shares_before,
             total_if_shares_before,
             if_shares_after,
@@ -363,7 +390,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // # Panics / Errors
     // * If no withdrawal request is currently in progress.
     // * If rebase metadata is inconsistent (e.g., base mismatch).
-    fn cancel_request_withdraw(e: Env, user: Address) {
+    fn cancel_request_withdraw(e: Env, user: Address, token: Address) {
         user.require_auth();
 
         enter(&e);
@@ -378,46 +405,46 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::NoIFWithdrawRequestInProgress
         );
 
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
+        let reserve = get_reserve(&e, &token);
 
         apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
         apply_rebase_to_stake(&e, &mut stake);
 
-        let total_shares = get_total_shares(&e);
-        let shares_base = get_shares_base(&e);
+        let reserve_after_rebase = get_reserve(&e, &token);
 
         let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = total_shares;
+        let total_if_shares_before = reserve_after_rebase.total_shares;
 
         //  "if stake base != base"
         validate!(
             &e,
-            stake.if_base == shares_base,
+            stake.if_base == reserve_after_rebase.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        let if_shares_lost = calculate_if_shares_lost(&e, &stake, insurance_vault_amount);
+        let if_shares_lost = calculate_shares_lost(&e, &stake, &reserve);
 
         stake.decrease_if_shares(&e, if_shares_lost);
 
         validate!(
             &e,
-            total_shares >= if_shares_lost,
+            reserve_after_rebase.total_shares >= if_shares_lost,
             InsuranceFundError::InsufficientIFShares
         );
-        set_total_shares(&e, &(total_shares - if_shares_lost));
+        set_total_shares(&e, &(total_shares - if_shares_lost)); // FIXME:
 
         let if_shares_after = stake.checked_if_shares(&e);
 
         FundEvents::new(&e).if_stake_record(
             user.clone(),
+            token.clone(),
             StakeAction::WithdrawCancelRequest,
             0,
-            insurance_vault_amount,
+            reserve_after_rebase.balance,
             if_shares_before,
             total_if_shares_before,
             if_shares_after,
-            total_shares,
+            reserve_after_rebase.total_shares,
         );
 
         stake.last_withdraw_request_shares = 0;
@@ -462,7 +489,7 @@ impl InsuranceFundTrait for InsuranceFund {
     // * If no withdrawal request exists or the waiting period hasn't passed.
     // * If stake state or rebase base is invalid.
     // * If the vault balance would be zero after withdrawal.
-    fn withdraw(e: Env, user: Address) {
+    fn withdraw(e: Env, user: Address, token: Address) {
         user.require_auth();
 
         enter(&e);
@@ -492,7 +519,7 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::TryingToRemoveLiquidityTooFast
         );
 
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
+        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
 
         apply_rebase_to_insurance_fund(&e, insurance_vault_amount);
         apply_rebase_to_stake(&e, &mut stake);
@@ -513,9 +540,9 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::InsufficientIFShares
         );
 
-        let amount = if_shares_to_vault_amount(&e, n_shares, total_shares, insurance_vault_amount);
+        let amount = shares_to_reserve_amount(&e, n_shares, total_shares, insurance_vault_amount);
 
-        let _if_shares_lost = calculate_if_shares_lost(&e, &stake, insurance_vault_amount);
+        let _if_shares_lost = calculate_shares_lost(&e, &stake, insurance_vault_amount);
 
         let withdraw_amount = amount.min(stake.last_withdraw_request_value);
 
@@ -546,6 +573,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         FundEvents::new(&e).if_stake_record(
             user.clone(),
+            token.clone(),
             StakeAction::Withdraw,
             withdraw_amount,
             insurance_vault_amount,
@@ -559,14 +587,14 @@ impl InsuranceFundTrait for InsuranceFund {
 
         transfer_token(
             &e,
-            &get_token(&e),
+            &token,
             &e.current_contract_address(),
             &user,
             &(withdraw_amount as i128),
         );
 
-        let insurance_vault_amount = get_insurance_vault_amount(&e);
-        // "insurance_fund_vault.amount must remain > 0"
+        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
+
         validate!(
             &e,
             insurance_vault_amount > 0,
@@ -615,15 +643,16 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(&e, InsuranceFundError::NotAuthorized)
         }
 
+        let premium_token = get_premium_token(&e);
         transfer_token(
             &e,
-            &get_token(&e),
+            &premium_token,
             &sender,
             &e.current_contract_address(),
             &(amount as i128),
         );
 
-        FundEvents::new(&e).collect_premium(sender, amount);
+        FundEvents::new(&e).collect_premium(sender, premium_token, amount);
 
         exit(&e);
     }
@@ -636,8 +665,12 @@ impl InsuranceFundTrait for InsuranceFund {
     // (:   _(  _|(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     //  \_______)  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
-    fn get_token(e: Env) -> Address {
-        get_token(&e)
+    fn get_whitelist_tokens(e: Env) -> Vec<Address> {
+        get_whitelist_tokens(&e)
+    }
+
+    fn get_deletion_queue_tokens(e: Env) -> Vec<Address> {
+        get_deletion_queue(&e)
     }
 
     fn get_pool_router(e: Env) -> Address {
@@ -976,6 +1009,46 @@ impl AdminInterface for InsuranceFund {
         require_admin(&e, &admin);
 
         set_pool_router(&e, &pool_router);
+    }
+
+    fn add_whitelist_token(e: Env, admin: Address, token: Address) {
+        admin.require_auth();
+        require_admin(&e, &admin);
+
+        validate_token_contract(&e, &token);
+
+        let whitelist = get_whitelist_tokens(&e);
+        let deletion_queue = get_deletion_queue(&e);
+
+        if deletion_queue.contains(&token) {}
+
+        if whitelist.contains(&token) {}
+
+        FundEvents::new(&e).whitelist_token(admin, token);
+    }
+
+    fn remove_whitelist_token(e: Env, admin: Address, token: Address) {
+        admin.require_auth();
+        require_admin(&e, &admin);
+
+        let deletion_queue = get_deletion_queue(&e);
+
+        if deletion_queue.contains(&token) {
+            panic_with_error!(&e, InsuranceFundError::TokenAlreadyDeleted);
+        }
+
+        let whitelist = get_whitelist_tokens(&e);
+
+        if !whitelist.contains(&token) {
+            panic_with_error!(&e, InsuranceFundError::TokenAlreadyDeleted);
+        }
+
+        let reserve = get_reserve(&e, &token);
+
+        // remove from whitelist
+        // add to queue
+
+        FundEvents::new(&e).remove_whitelist_token(admin, token, reserve.balance);
     }
 
     fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64) {

--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -12,24 +12,21 @@ use crate::stake::{
     reserve_amount_to_shares, save_stake, shares_to_reserve_amount, StakeAction,
 };
 use crate::storage::get_contract_token_balance;
-use crate::storage::get_deletion_queue;
-use crate::storage::get_pool_router;
 use crate::storage::get_oracle_registry;
+use crate::storage::get_pool_router;
+use crate::storage::get_premium_payer_status;
 use crate::storage::get_premium_token;
-use crate::storage::get_premium_whitelist_status;
 use crate::storage::get_reserve;
+use crate::storage::get_token_whitelist;
 use crate::storage::get_token_whitelist_status;
 use crate::storage::put_reserve;
 use crate::storage::set_oracle_registry;
 use crate::storage::set_pool_router;
+use crate::storage::set_premium_payer_status;
 use crate::storage::set_premium_token;
+use crate::storage::set_token_whitelist;
+use crate::storage::WhitelistToken;
 use crate::storage::{
-    get_base_rate, get_is_killed_deposit,
-    get_is_killed_request_withdraw, get_is_killed_withdraw, get_optimal_insurance,
-    get_optimal_utilization, get_rate_slope_a, get_rate_slope_b, get_unstaking_period,
-    set_base_rate, set_is_killed_deposit, set_is_killed_request_withdraw, set_is_killed_withdraw,
-    set_optimal_insurance, set_optimal_utilization, set_rate_slope_a, set_rate_slope_b,
-    set_unstaking_period,
     get_base_rate, get_is_killed_deposit, get_is_killed_request_withdraw, get_is_killed_withdraw,
     get_optimal_insurance, get_optimal_utilization, get_rate_slope_a, get_rate_slope_b,
     get_unstaking_period, set_base_rate, set_is_killed_deposit, set_is_killed_request_withdraw,
@@ -56,7 +53,6 @@ use upgrade::interface::UpgradeableContract;
 use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
 use utils::math::safe_math::SafeMath;
 use utils::state::pool::PoolInfo;
-use utils::state::token::DetailedToken;
 use utils::token::transfer_token;
 use utils::token::validate_token_contract;
 use utils::token::validate_token_contracts;
@@ -82,8 +78,7 @@ impl InsuranceFundTrait for InsuranceFund {
         oracle_registry: Address,
         pool_router: Address,
         premium_token: Address,
-        whitelisted_tokens: Vec<Address>,
-        oracle_registry: Address,
+        whitelisted_tokens: Vec<WhitelistToken>,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -98,20 +93,23 @@ impl InsuranceFundTrait for InsuranceFund {
         access_control.set_role_address(&Role::Admin, &admin);
         access_control.set_role_address(&Role::EmergencyAdmin, &emergency_admin);
 
-        set_oracle_registry(&e, &token);
+        set_oracle_registry(&e, &oracle_registry);
         set_pool_router(&e, &pool_router);
+
         validate_token_contract(&e, &premium_token);
-        validate_token_contracts(&e, &whitelisted_tokens);
+        set_premium_token(&e, &premium_token);
 
         for i in 0..whitelisted_tokens.len() {
             let token = whitelisted_tokens.get(i).unwrap();
-            let reserve = get_reserve(&e, &token);
-            put_reserve(&e, &token, &reserve);
+
+            validate_token_contract(&e, &token.address);
+
+            set_token_whitelist(&e, &token);
+
+            let reserve = get_reserve(&e, &token.address);
+            put_reserve(&e, &token.address, &reserve);
         }
 
-        set_oracle_registry(&e, &oracle_registry);
-        set_premium_token(&e, &premium_token);
-        set_whitelist_tokens(&e, &whitelisted_tokens);
         set_unstaking_period(&e, &unstaking_period);
         set_optimal_utilization(&e, &optimal_utilization);
         set_base_rate(&e, &base_rate);
@@ -286,9 +284,9 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundRequestWithdrawKilled);
         }
 
-        if !get_token_whitelist_status(&e, &token) {
-            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
-        }
+        // Withdrawals do not require a whitelist token to be active. Inactive tokens
+        // must be withdrawn so the reserve.balance equals zero before they can be removed.
+        get_token_whitelist(&e, &token);
 
         let now = e.ledger().timestamp();
         let mut stake = get_stake(&e, &user, &token);
@@ -409,9 +407,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        if !get_token_whitelist_status(&e, &token) {
-            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
-        }
+        get_token_whitelist(&e, &token);
 
         let now = e.ledger().timestamp();
         let mut stake = get_stake(&e, &user, &token);
@@ -516,9 +512,7 @@ impl InsuranceFundTrait for InsuranceFund {
             panic_with_error!(e, InsuranceFundError::FundWithdrawKilled);
         }
 
-        if !get_token_whitelist_status(&e, &token) {
-            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
-        }
+        get_token_whitelist(&e, &token);
 
         // TODO: Do we need to check IF utilization and/or overall pool liquidity imbalance for edge
         // cases before authorizing a withdrawal?
@@ -540,8 +534,6 @@ impl InsuranceFundTrait for InsuranceFund {
             time_since_withdraw_request >= get_unstaking_period(&e),
             InsuranceFundError::TryingToRemoveLiquidityTooFast
         );
-
-        let insurance_vault_amount = get_insurance_vault_amount(&e, &token);
 
         apply_rebase_to_insurance_fund(&e, &token);
         apply_rebase_to_stake(&e, &mut stake);
@@ -662,8 +654,8 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        if !get_premium_whitelist_status(&e, &sender) {
-            panic_with_error!(&e, InsuranceFundError::NotAuthorized)
+        if !get_premium_payer_status(&e, &sender) {
+            panic_with_error!(&e, InsuranceFundError::NotAuthorized);
         }
 
         let premium_token = get_premium_token(&e);
@@ -691,9 +683,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        if !get_token_whitelist_status(&e, &token) {
-            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
-        }
+        get_token_whitelist(&e, &token);
 
         let now = e.ledger().timestamp();
         let reserve = get_reserve(&e, &token);
@@ -715,9 +705,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         enter(&e);
 
-        if !get_token_whitelist_status(&e, &token) {
-            panic_with_error!(e, InsuranceFundError::UnsupportedToken);
-        }
+        get_token_whitelist(&e, &token);
 
         let reserve = get_reserve(&e, &token);
         let balance = get_contract_token_balance(&e, &token);
@@ -738,16 +726,16 @@ impl InsuranceFundTrait for InsuranceFund {
     // (:   _(  _|(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     //  \_______)  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
-    fn get_whitelist_tokens(e: Env) -> Vec<Address> {
-        get_whitelist_tokens(&e)
-    }
-
-    fn get_deletion_queue_tokens(e: Env) -> Vec<Address> {
-        get_deletion_queue(&e)
+    fn get_oracle_registry(e: Env) -> Address {
+        get_oracle_registry(&e)
     }
 
     fn get_pool_router(e: Env) -> Address {
         get_pool_router(&e)
+    }
+
+    fn get_premium_token(e: Env) -> Address {
+        get_premium_token(&e)
     }
 
     fn get_unstaking_period(e: Env) -> u64 {
@@ -810,8 +798,12 @@ impl InsuranceFundTrait for InsuranceFund {
         (get_rate_slope_a(&e), get_rate_slope_b(&e))
     }
 
-    fn get_premium_whitelist_status(e: Env, address: Address) -> bool {
-        crate::storage::get_premium_whitelist_status(&e, &address)
+    fn get_token_whitelist(e: Env, token: Address) -> WhitelistToken {
+        get_token_whitelist(&e, &token)
+    }
+
+    fn get_premium_payer_status(e: Env, address: Address) -> bool {
+        get_premium_payer_status(&e, &address)
     }
 }
 
@@ -998,7 +990,7 @@ impl AdminInterface for InsuranceFund {
     // # Panics / Errors
     // * `InsuranceFundError::InsufficientCollateral` if the claim exceeds vault balance.
     // * `InsuranceFundError::InvalidIFDetected` if the payout fully depletes the Insurance Fund.
-    fn resolve_liquidity_deficit(e: Env, admin: Address, asset: Symbol) {
+    fn resolve_liquidity_deficit(e: Env, admin: Address, token: Address, asset: Symbol) {
         admin.require_auth();
         require_admin(&e, &admin);
 
@@ -1046,15 +1038,15 @@ impl AdminInterface for InsuranceFund {
                             // Error if there is not enough insurance to cover the claim
                             validate!(
                                 &e,
-                                pay_from_insurance < insurance_vault_amount,
+                                pay_from_insurance < reserve.balance,
                                 InsuranceFundError::InsufficientCollateral
                             );
 
                             // Error if a claim leaves removes all insurance
-                            let new_insurance_vault_amount = get_insurance_vault_amount(&e);
+                            let updated_reserve = get_reserve(&e, &token);
                             validate!(
                                 &e,
-                                new_insurance_vault_amount > 0,
+                                updated_reserve.balance > 0,
                                 InsuranceFundError::InvalidIFDetected
                             );
                         }
@@ -1074,6 +1066,13 @@ impl AdminInterface for InsuranceFund {
     //  /" \   :)(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     // (_______/  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
+    fn set_oracle_registry(e: Env, admin: Address, oracle_registry: Address) {
+        admin.require_auth();
+        require_admin(&e, &admin);
+
+        set_oracle_registry(&e, &oracle_registry);
+    }
+
     fn set_pool_router(e: Env, admin: Address, pool_router: Address) {
         admin.require_auth();
         require_admin(&e, &admin);
@@ -1081,51 +1080,22 @@ impl AdminInterface for InsuranceFund {
         set_pool_router(&e, &pool_router);
     }
 
-    fn add_whitelist_token(e: Env, admin: Address, token: DetailedToken) {
+    fn set_premium_payer_status(e: Env, admin: Address, payer: Address, status: bool) {
         admin.require_auth();
         require_admin(&e, &admin);
 
-        validate_token_contract(&e, &token.address);
+        let old_status = get_premium_payer_status(&e, &payer);
+        set_premium_payer_status(&e, &payer, status);
 
-        // Validate oracle
-        e.invoke_contract(
-            &get_oracle_registry(&e),
-            &Symbol::new(&e, "get_price"),
-            Vec::from_array(&e, [token.symbol.to_val()]),
+        let current_time = e.ledger().timestamp();
+
+        FundEvents::new(&e).premium_payer_status_updated(
+            current_time,
+            admin,
+            payer,
+            old_status,
+            status,
         );
-
-        let whitelist = get_whitelist_tokens(&e);
-        let deletion_queue = get_deletion_queue(&e);
-
-        if deletion_queue.contains(&token.address) {}
-
-        if whitelist.contains(&token.address) {}
-
-        FundEvents::new(&e).whitelist_token(admin, token);
-    }
-
-    fn remove_whitelist_token(e: Env, admin: Address, token: DetailedToken) {
-        admin.require_auth();
-        require_admin(&e, &admin);
-
-        let deletion_queue = get_deletion_queue(&e);
-
-        if deletion_queue.contains(&token) {
-            panic_with_error!(&e, InsuranceFundError::TokenAlreadyDeleted);
-        }
-
-        let whitelist = get_whitelist_tokens(&e);
-
-        if !whitelist.contains(&token) {
-            panic_with_error!(&e, InsuranceFundError::TokenAlreadyDeleted);
-        }
-
-        let reserve = get_reserve(&e, &token);
-
-        // remove from whitelist
-        // add to queue
-
-        FundEvents::new(&e).remove_whitelist_token(admin, token, reserve.balance);
     }
 
     fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64) {
@@ -1165,23 +1135,63 @@ impl AdminInterface for InsuranceFund {
         set_rate_slope_b(&e, &rate_slope_b);
     }
 
-    fn set_whitelist_status(e: Env, admin: Address, address: Address, status: bool) {
+    fn add_token_whitelist(e: Env, admin: Address, token: WhitelistToken) {
         admin.require_auth();
-        let access_control = AccessControl::new(&e);
-        access_control.assert_address_has_role(&admin, &Role::Admin);
+        require_admin(&e, &admin);
 
-        let old_status = get_premium_whitelist_status(&e, &address);
-        crate::storage::set_premium_whitelist_status(&e, &address, status);
+        // Error if token already exists
+        if get_token_whitelist_status(&e, &token.address) {
+            panic_with_error!(&e, InsuranceFundError::AdminNotSet);
+        }
 
-        let current_time = e.ledger().timestamp();
-        // Emit enhanced event
-        FundEvents::new(&e).premium_whitelist_status_updated(
-            current_time,
-            admin,
-            address,
-            old_status,
-            status,
+        validate_token_contract(&e, &token.address);
+
+        // Validate oracle
+        e.invoke_contract(
+            &get_oracle_registry(&e),
+            &Symbol::new(&e, "get_price"),
+            Vec::from_array(&e, [token.symbol.to_val()]),
         );
+
+        set_token_whitelist(&e, &token);
+
+        FundEvents::new(&e).whitelist_token(admin, token.address, token.symbol);
+    }
+
+    fn set_token_whitelist_status(e: Env, admin: Address, token: Address, status: bool) {
+        admin.require_auth();
+        require_admin(&e, &admin);
+
+        let token = get_token_whitelist(&e, &token);
+
+        set_token_whitelist(
+            &e,
+            &(WhitelistToken {
+                active: status,
+                ..token
+            }),
+        );
+    }
+
+    fn remove_whitelist_token(e: Env, admin: Address, token: Address) {
+        admin.require_auth();
+        require_admin(&e, &admin);
+
+        let token = get_token_whitelist(&e, &token);
+
+        // Error if not inactive token
+        if token.active {
+            panic_with_error!(&e, InsuranceFundError::AdminNotSet);
+        }
+
+        let reserve = get_reserve(&e, &token.address);
+
+        // Error if reserve has not been depleted yet
+        if reserve.balance != 0 {
+            panic_with_error!(&e, InsuranceFundError::AdminNotSet);
+        }
+
+        FundEvents::new(&e).remove_whitelist_token(admin, token.address, reserve.balance);
     }
 
     //    _______     __       ____  ____   ________  _______  ________

--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -522,9 +522,6 @@ impl InsuranceFundTrait for InsuranceFund {
 
         get_token_whitelist(&e, &token);
 
-        // TODO: Do we need to check IF utilization and/or overall pool liquidity imbalance for edge
-        // cases before authorizing a withdrawal?
-
         let now = e.ledger().timestamp();
         let mut stake = get_stake(&e, &user, &token);
 
@@ -578,7 +575,7 @@ impl InsuranceFundTrait for InsuranceFund {
             stake.cost_basis >= withdraw_amount,
             InsuranceFundError::CostBasisUnderflow
         );
-        stake.cost_basis = stake.cost_basis - withdraw_amount;
+        stake.cost_basis = stake.cost_basis.saturating_sub(withdraw_amount);
 
         // Add bounds checking to prevent critical share tracking underflow
         validate!(
@@ -589,7 +586,7 @@ impl InsuranceFundTrait for InsuranceFund {
 
         reserve.remove_total_shares(n_shares, now);
 
-        // reset stake withdraw request info
+        // Reset stake withdraw request info
         stake.last_withdraw_request_shares = 0;
         stake.last_withdraw_request_value = 0;
         stake.last_withdraw_request_ts = now;
@@ -598,7 +595,7 @@ impl InsuranceFundTrait for InsuranceFund {
         reserve.save(&e);
         stake.save(&e);
 
-        // Send tokens from the fund to the user
+        // Send tokens from the Fund to the user
         transfer_token(
             &e,
             &token,
@@ -723,8 +720,10 @@ impl InsuranceFundTrait for InsuranceFund {
         get_token_whitelist(&e, &token);
 
         let reserve = get_reserve(&e, &token);
+
         let balance = get_contract_token_balance(&e, &token);
         let skimmed = balance.saturating_sub(reserve.balance) as i128;
+
         if skimmed > 0 {
             transfer_token(&e, &token, &e.current_contract_address(), &sender, &skimmed);
             FundEvents::new(&e).skim(sender, token, skimmed);

--- a/contracts/insurance_fund/src/contract.rs
+++ b/contracts/insurance_fund/src/contract.rs
@@ -5,6 +5,7 @@ use crate::interest::calculate_rate;
 use crate::interest::calculate_total_reserve_value;
 use crate::interest::calculate_utilization;
 use crate::interface::{AdminInterface, InsuranceFundTrait};
+use crate::reserve;
 use crate::reserve::InsuranceFundReserve;
 use crate::stake::Stake;
 use crate::stake::{
@@ -19,12 +20,15 @@ use crate::storage::get_premium_token;
 use crate::storage::get_reserve;
 use crate::storage::get_token_whitelist;
 use crate::storage::get_token_whitelist_status;
+use crate::storage::get_token_whitelist_vec;
 use crate::storage::put_reserve;
+use crate::storage::remove_token_whitelist;
 use crate::storage::set_oracle_registry;
 use crate::storage::set_pool_router;
 use crate::storage::set_premium_payer_status;
 use crate::storage::set_premium_token;
 use crate::storage::set_token_whitelist;
+use crate::storage::set_token_whitelist_vec;
 use crate::storage::WhitelistToken;
 use crate::storage::{
     get_base_rate, get_is_killed_deposit, get_is_killed_request_withdraw, get_is_killed_withdraw,
@@ -55,14 +59,13 @@ use utils::math::safe_math::SafeMath;
 use utils::state::pool::PoolInfo;
 use utils::token::transfer_token;
 use utils::token::validate_token_contract;
-use utils::token::validate_token_contracts;
 use utils::validate;
 use utils::validation::ensure_non_zero_u128;
 use utils::validation::validate_percentages;
 
 contractmeta!(
     key = "Description",
-    val = "Junior tranche (last payout) backstop fund to cover pool liquidity deficits using user staked funds"
+    val = "Backstop fund to cover pool liquidity deficits"
 );
 
 #[contract]
@@ -78,7 +81,6 @@ impl InsuranceFundTrait for InsuranceFund {
         oracle_registry: Address,
         pool_router: Address,
         premium_token: Address,
-        whitelisted_tokens: Vec<WhitelistToken>,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -98,17 +100,6 @@ impl InsuranceFundTrait for InsuranceFund {
 
         validate_token_contract(&e, &premium_token);
         set_premium_token(&e, &premium_token);
-
-        for i in 0..whitelisted_tokens.len() {
-            let token = whitelisted_tokens.get(i).unwrap();
-
-            validate_token_contract(&e, &token.address);
-
-            set_token_whitelist(&e, &token);
-
-            let reserve = get_reserve(&e, &token.address);
-            put_reserve(&e, &token.address, &reserve);
-        }
 
         set_unstaking_period(&e, &unstaking_period);
         set_optimal_utilization(&e, &optimal_utilization);
@@ -157,84 +148,88 @@ impl InsuranceFundTrait for InsuranceFund {
     fn deposit(e: Env, user: Address, token: Address, amount: u128) {
         user.require_auth();
 
+        // Validations
+        validate_token_contract(&e, &token);
         ensure_non_zero_u128(&e, amount);
 
+        // Re-entrancy check
         enter(&e);
 
+        // Status check
         if get_is_killed_deposit(&e) {
             panic_with_error!(e, InsuranceFundError::FundDepositKilled);
         }
 
+        // Whitelisted token check
         if !get_token_whitelist_status(&e, &token) {
             panic_with_error!(e, InsuranceFundError::UnsupportedToken);
         }
 
+        let now = e.ledger().timestamp();
         let optimal_insurance = get_optimal_insurance(&e);
-        let reserve = get_reserve(&e, &token);
+
+        let mut reserve = get_reserve(&e, &token);
+        let reserve_balance_before = reserve.balance;
 
         // Ensure the new stake will not exceed the optimal insurance
         validate!(
             e,
-            reserve.balance + amount <= optimal_insurance,
+            reserve_balance_before + amount <= optimal_insurance,
             InsuranceFundError::TooMuchInsurance
         );
 
         let mut stake = get_stake(&e, &user, &token);
 
-        // Error if a withdrawal request is in progress
+        // Error if a withdrawal request is already in progress
         validate!(
             &e,
             stake.last_withdraw_request_shares == 0 && stake.last_withdraw_request_value == 0,
             InsuranceFundError::IFWithdrawRequestInProgress
         );
 
-        // Rebase Insurance Fund and Stake
-        apply_rebase_to_insurance_fund(&e, &token);
+        // Rebase the Insurance Fund and Stake
+        apply_rebase_to_insurance_fund(&e, &mut reserve);
         apply_rebase_to_stake(&e, &mut stake);
 
-        // Get updated Reserve after rebase
-        let reserve = get_reserve(&e, &token);
-
-        let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = reserve.total_shares;
+        let stake_shares_before = stake.checked_shares(&e);
+        let total_shares_before = reserve.total_shares;
 
         let n_shares = reserve_amount_to_shares(&e, amount, &reserve);
 
-        // reset cost basis if no shares
-        stake.cost_basis = if if_shares_before == 0 {
+        // Reset cost basis if no shares
+        stake.cost_basis = if stake_shares_before == 0 {
             amount
         } else {
-            stake.cost_basis.safe_add(&e, amount)
+            stake.cost_basis.saturating_add(amount)
         };
 
-        stake.increase_if_shares(&e, n_shares);
+        // Increase the Fund and Stake shares
+        stake.increase_shares(&e, n_shares);
+        reserve.add_total_shares(n_shares, now);
 
-        set_total_shares(&e, &(reserve.total_shares + n_shares));
+        // Update the Reserve and Stake
+        reserve.save(&e);
+        stake.save(&e);
 
-        let if_shares_after = stake.checked_if_shares(&e);
-
-        let new_total_shares = get_total_shares(&e);
-
-        FundEvents::new(&e).if_stake_record(
-            user.clone(),
-            token.clone(),
-            StakeAction::Deposit,
-            amount,
-            reserve.balance,
-            if_shares_before,
-            total_if_shares_before,
-            if_shares_after,
-            new_total_shares,
-        );
-
-        save_stake(&e, &user, &token, &stake);
-
+        // Deposit tokens from the user to the Fund
         transfer_token(
             &e,
             &token,
             &user,
             &e.current_contract_address(),
             &(amount as i128),
+        );
+
+        FundEvents::new(&e).insurance_stake_record(
+            user.clone(),
+            token.clone(),
+            StakeAction::Deposit,
+            amount,
+            reserve_balance_before,
+            stake_shares_before,
+            total_shares_before,
+            stake.shares,
+            reserve.total_shares,
         );
 
         exit(&e);
@@ -276,10 +271,14 @@ impl InsuranceFundTrait for InsuranceFund {
     fn request_withdraw(e: Env, user: Address, token: Address, amount: u128) {
         user.require_auth();
 
+        // Validations
+        validate_token_contract(&e, &token);
         ensure_non_zero_u128(&e, amount);
 
+        // Re-entrancy check
         enter(&e);
 
+        // Status check
         if get_is_killed_request_withdraw(&e) {
             panic_with_error!(e, InsuranceFundError::FundRequestWithdrawKilled);
         }
@@ -298,8 +297,10 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::IFWithdrawRequestInProgress
         );
 
+        let mut reserve = get_reserve(&e, &token);
+        let reserve_balance_before = reserve.balance;
+
         // Convert token amount to # of shares
-        let reserve = get_reserve(&e, &token);
         let n_shares = reserve_amount_to_shares(&e, amount, &reserve);
 
         validate!(
@@ -309,44 +310,38 @@ impl InsuranceFundTrait for InsuranceFund {
         );
 
         // Error if user does not have enough shares to satisfy the request
-        let user_if_shares = stake.checked_if_shares(&e);
+        let stake_shares = stake.checked_shares(&e);
         validate!(
             &e,
-            user_if_shares >= n_shares,
+            stake_shares >= n_shares,
             InsuranceFundError::InsufficientIFShares
         );
 
-        // Update the user stake
+        // Update the Stake
         stake.last_withdraw_request_shares = n_shares;
 
-        apply_rebase_to_insurance_fund(&e, &token);
+        // Rebase the Insurance Fund and Stake
+        apply_rebase_to_insurance_fund(&e, &mut reserve);
         apply_rebase_to_stake(&e, &mut stake);
 
-        // Get post rebase values
-        let reserve_after_rebase = get_reserve(&e, &token);
-        let stake_after_rebase = get_stake(&e, &user, &token);
-
-        let if_shares_before = stake_after_rebase.checked_if_shares(&e);
-        let total_if_shares_before = reserve_after_rebase.total_shares;
+        let stake_shares_before = stake.checked_shares(&e);
+        let total_shares_before = reserve.total_shares;
 
         validate!(
             &e,
-            stake.last_withdraw_request_shares <= stake.checked_if_shares(&e),
+            stake.last_withdraw_request_shares <= stake.checked_shares(&e),
             InsuranceFundError::InvalidInsuranceUnstakeSize
         );
 
         validate!(
             &e,
-            stake.if_base == reserve_after_rebase.shares_base,
+            stake.base == reserve.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        stake.last_withdraw_request_value = shares_to_reserve_amount(
-            &e,
-            stake.last_withdraw_request_shares,
-            &reserve_after_rebase,
-        )
-        .min(reserve_after_rebase.balance.saturating_sub(1));
+        stake.last_withdraw_request_value =
+            shares_to_reserve_amount(&e, stake.last_withdraw_request_shares, &reserve)
+                .min(reserve.balance.saturating_sub(1));
 
         validate!(
             &e,
@@ -355,23 +350,23 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::InvalidIFUnstakeSize
         );
 
-        let if_shares_after = stake.checked_if_shares(&e);
+        stake.last_withdraw_request_ts = now;
 
-        FundEvents::new(&e).if_stake_record(
+        // Update the Reserve and Stake
+        reserve.save(&e);
+        stake.save(&e);
+
+        FundEvents::new(&e).insurance_stake_record(
             user.clone(),
             token.clone(),
             StakeAction::WithdrawRequest,
             stake.last_withdraw_request_value,
-            reserve.balance,
-            if_shares_before,
-            total_if_shares_before,
-            if_shares_after,
-            reserve_after_rebase.total_shares,
+            reserve_balance_before,
+            stake_shares_before,
+            total_shares_before,
+            stake.shares,
+            reserve.total_shares,
         );
-
-        stake.last_withdraw_request_ts = now;
-
-        save_stake(&e, &user, &token, &stake);
 
         exit(&e);
     }
@@ -405,67 +400,75 @@ impl InsuranceFundTrait for InsuranceFund {
     fn cancel_request_withdraw(e: Env, user: Address, token: Address) {
         user.require_auth();
 
+        // Validations
+        validate_token_contract(&e, &token);
+
+        // Re-entrancy check
         enter(&e);
 
+        // Whitelist token check
         get_token_whitelist(&e, &token);
 
         let now = e.ledger().timestamp();
         let mut stake = get_stake(&e, &user, &token);
 
-        //  "No withdraw request in progress"
+        // No withdraw request in progress
         validate!(
             &e,
             stake.last_withdraw_request_shares != 0,
             InsuranceFundError::NoIFWithdrawRequestInProgress
         );
 
-        let reserve = get_reserve(&e, &token);
+        let mut reserve = get_reserve(&e, &token);
+        let reserve_balance_before = reserve.balance;
 
-        apply_rebase_to_insurance_fund(&e, &token);
+        // Rebase the Insurance Fund and Stake
+        apply_rebase_to_insurance_fund(&e, &mut reserve);
         apply_rebase_to_stake(&e, &mut stake);
 
-        let reserve_after_rebase = get_reserve(&e, &token);
+        let stake_shares_before = stake.checked_shares(&e);
+        let total_shares_before = reserve.total_shares;
 
-        let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = reserve_after_rebase.total_shares;
-
-        //  "if stake base != base"
+        // if stake base != base
         validate!(
             &e,
-            stake.if_base == reserve_after_rebase.shares_base,
+            stake.base == reserve.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        let if_shares_lost = calculate_shares_lost(&e, &stake, &reserve);
+        // Decrease the Stake shares
+        let stake_shares_lost = calculate_shares_lost(&e, &stake, &reserve);
 
-        stake.decrease_if_shares(&e, if_shares_lost);
+        stake.decrease_shares(&e, stake_shares_lost);
 
         validate!(
             &e,
-            reserve_after_rebase.total_shares >= if_shares_lost,
+            reserve.total_shares >= stake_shares_lost,
             InsuranceFundError::InsufficientIFShares
         );
-        set_total_shares(&e, &(total_shares - if_shares_lost)); // FIXME:
 
-        let if_shares_after = stake.checked_if_shares(&e);
-
-        FundEvents::new(&e).if_stake_record(
-            user.clone(),
-            token.clone(),
-            StakeAction::WithdrawCancelRequest,
-            0,
-            reserve_after_rebase.balance,
-            if_shares_before,
-            total_if_shares_before,
-            if_shares_after,
-            reserve_after_rebase.total_shares,
-        );
+        // Decrease the Fund shares
+        reserve.remove_total_shares(stake_shares_lost, now);
 
         stake.last_withdraw_request_shares = 0;
         stake.last_withdraw_request_value = 0;
         stake.last_withdraw_request_ts = now;
 
-        save_stake(&e, &user, &token, &stake);
+        // Update the Reserve and Stake
+        reserve.save(&e);
+        stake.save(&e);
+
+        FundEvents::new(&e).insurance_stake_record(
+            user.clone(),
+            token.clone(),
+            StakeAction::WithdrawCancelRequest,
+            0,
+            reserve_balance_before,
+            stake_shares_before,
+            total_shares_before,
+            stake.shares,
+            reserve.total_shares,
+        );
 
         exit(&e);
     }
@@ -506,8 +509,13 @@ impl InsuranceFundTrait for InsuranceFund {
     fn withdraw(e: Env, user: Address, token: Address) {
         user.require_auth();
 
+        // Validations
+        validate_token_contract(&e, &token);
+
+        // Re-entrancy check
         enter(&e);
 
+        // Status check
         if get_is_killed_withdraw(&e) {
             panic_with_error!(e, InsuranceFundError::FundWithdrawKilled);
         }
@@ -535,33 +543,34 @@ impl InsuranceFundTrait for InsuranceFund {
             InsuranceFundError::TryingToRemoveLiquidityTooFast
         );
 
-        apply_rebase_to_insurance_fund(&e, &token);
+        let mut reserve = get_reserve(&e, &token);
+        let reserve_balance_before = reserve.balance;
+
+        // Rebase the Insurance Fund and Stake
+        apply_rebase_to_insurance_fund(&e, &mut reserve);
         apply_rebase_to_stake(&e, &mut stake);
 
-        // let total_shares = get_total_shares(&e);
-        let reserve_after_rebase = get_reserve(&e, &token);
-
-        let if_shares_before = stake.checked_if_shares(&e);
-        let total_if_shares_before = reserve_after_rebase.total_shares;
+        let stake_shares_before = stake.checked_shares(&e);
+        let total_shares_before = reserve.total_shares;
 
         let n_shares = stake.last_withdraw_request_shares;
 
-        //  "Must submit withdraw request and wait the escrow period"
+        // Must submit withdraw request and wait the escrow period
         validate!(&e, n_shares > 0, InsuranceFundError::InvalidIFUnstake);
 
         validate!(
             &e,
-            if_shares_before >= n_shares,
+            stake_shares_before >= n_shares,
             InsuranceFundError::InsufficientIFShares
         );
 
-        let amount = shares_to_reserve_amount(&e, n_shares, &reserve_after_rebase);
+        let amount = shares_to_reserve_amount(&e, n_shares, &reserve);
 
-        let _if_shares_lost = calculate_shares_lost(&e, &stake, &reserve_after_rebase);
+        let _if_shares_lost = calculate_shares_lost(&e, &stake, &reserve);
 
         let withdraw_amount = amount.min(stake.last_withdraw_request_value);
 
-        stake.decrease_if_shares(&e, n_shares);
+        stake.decrease_shares(&e, n_shares);
 
         // Add bounds checking to prevent underflow when withdrawing more than cost basis
         validate!(
@@ -574,32 +583,22 @@ impl InsuranceFundTrait for InsuranceFund {
         // Add bounds checking to prevent critical share tracking underflow
         validate!(
             &e,
-            reserve_after_rebase.total_shares >= n_shares,
+            reserve.total_shares >= n_shares,
             InsuranceFundError::InsufficientIFShares
         );
-        set_total_shares(&e, &(total_shares - n_shares));
+
+        reserve.remove_total_shares(n_shares, now);
 
         // reset stake withdraw request info
         stake.last_withdraw_request_shares = 0;
         stake.last_withdraw_request_value = 0;
         stake.last_withdraw_request_ts = now;
 
-        let if_shares_after = stake.checked_if_shares(&e);
+        // Update the Reserve and Stake
+        reserve.save(&e);
+        stake.save(&e);
 
-        FundEvents::new(&e).if_stake_record(
-            user.clone(),
-            token.clone(),
-            StakeAction::Withdraw,
-            withdraw_amount,
-            insurance_vault_amount,
-            if_shares_before,
-            total_if_shares_before,
-            if_shares_after,
-            reserve_after_rebase.total_shares,
-        );
-
-        save_stake(&e, &user, &token, &stake);
-
+        // Send tokens from the fund to the user
         transfer_token(
             &e,
             &token,
@@ -608,8 +607,20 @@ impl InsuranceFundTrait for InsuranceFund {
             &(withdraw_amount as i128),
         );
 
-        let new_reserve = get_reserve(&e, &token);
+        FundEvents::new(&e).insurance_stake_record(
+            user.clone(),
+            token.clone(),
+            StakeAction::Withdraw,
+            withdraw_amount,
+            reserve_balance_before,
+            stake_shares_before,
+            total_shares_before,
+            stake.shares,
+            reserve.total_shares,
+        );
 
+        // Additional validation
+        let new_reserve = get_reserve(&e, &token);
         validate!(
             &e,
             new_reserve.balance > 0,
@@ -686,9 +697,13 @@ impl InsuranceFundTrait for InsuranceFund {
         get_token_whitelist(&e, &token);
 
         let now = e.ledger().timestamp();
-        let reserve = get_reserve(&e, &token);
+
         let balance = get_contract_token_balance(&e, &token);
-        put_reserve(&e, &token, &reserve.update_balance(balance, now));
+
+        let mut reserve = get_reserve(&e, &token);
+        reserve.update_balance(balance, now);
+        reserve.save(&e);
+
         FundEvents::new(&e).sync(sender, token, 0);
 
         exit(&e);
@@ -807,84 +822,6 @@ impl InsuranceFundTrait for InsuranceFund {
     }
 }
 
-// The `UpgradeableContract` trait provides the interface for upgrading the contract.
-#[contractimpl]
-impl UpgradeableContract for InsuranceFund {
-    // Returns the version of the contract.
-    //
-    // # Returns
-    //
-    // The version of the contract as a u32.
-    fn version() -> u32 {
-        100
-    }
-
-    // Commits a new wasm hash for a future upgrade.
-    // The upgrade will be available through `apply_upgrade` after the standard upgrade delay
-    // unless the system is in emergency mode.
-    //
-    // # Arguments
-    //
-    // * `admin` - The address of the admin.
-    // * `new_wasm_hash` - The new wasm hash to commit.
-    fn commit_upgrade(e: Env, admin: Address, new_wasm_hash: BytesN<32>) {
-        admin.require_auth();
-        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
-        commit_upgrade(&e, &new_wasm_hash);
-        UpgradeEvents::new(&e).commit_upgrade(Vec::from_array(&e, [new_wasm_hash.clone()]));
-    }
-
-    // Applies the committed upgrade.
-    //
-    // # Arguments
-    //
-    // * `admin` - The address of the admin.
-    fn apply_upgrade(e: Env, admin: Address) -> BytesN<32> {
-        admin.require_auth();
-        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
-        let new_wasm_hash = apply_upgrade(&e);
-        UpgradeEvents::new(&e).apply_upgrade(Vec::from_array(&e, [new_wasm_hash.clone()]));
-        new_wasm_hash
-    }
-
-    // Reverts the committed upgrade.
-    // This can be used to cancel a previously committed upgrade.
-    // The upgrade will be canceled only if it has not been applied yet.
-    // If the upgrade has already been applied, it cannot be reverted.
-    //
-    // # Arguments
-    //
-    // * `admin` - The address of the admin.
-    fn revert_upgrade(e: Env, admin: Address) {
-        admin.require_auth();
-        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
-        revert_upgrade(&e);
-        UpgradeEvents::new(&e).revert_upgrade();
-    }
-
-    // Sets the emergency mode.
-    // When the emergency mode is set to true, the contract will allow instant upgrades without the delay.
-    // This is useful in case of critical issues that need to be fixed immediately.
-    // When the emergency mode is set to false, the contract will require the standard upgrade delay.
-    // The emergency mode can only be set by the emergency admin.
-    //
-    // # Arguments
-    //
-    // * `emergency_admin` - The address of the emergency admin.
-    // * `value` - The value to set the emergency mode to.
-    fn set_emergency_mode(e: Env, emergency_admin: Address, value: bool) {
-        emergency_admin.require_auth();
-        AccessControl::new(&e).assert_address_has_role(&emergency_admin, &Role::EmergencyAdmin);
-        set_emergency_mode(&e, &value);
-        AccessControlEvents::new(&e).set_emergency_mode(value);
-    }
-
-    // Returns the emergency mode flag value.
-    fn get_emergency_mode(e: Env) -> bool {
-        get_emergency_mode(&e)
-    }
-}
-
 // The `AdminInterface` trait provides the interface for administrative actions.
 #[contractimpl]
 impl AdminInterface for InsuranceFund {
@@ -990,7 +927,7 @@ impl AdminInterface for InsuranceFund {
     // # Panics / Errors
     // * `InsuranceFundError::InsufficientCollateral` if the claim exceeds vault balance.
     // * `InsuranceFundError::InvalidIFDetected` if the payout fully depletes the Insurance Fund.
-    fn resolve_liquidity_deficit(e: Env, admin: Address, token: Address, asset: Symbol) {
+    fn file_claim(e: Env, admin: Address, token: Address, asset: Symbol) {
         admin.require_auth();
         require_admin(&e, &admin);
 
@@ -1147,13 +1084,21 @@ impl AdminInterface for InsuranceFund {
         validate_token_contract(&e, &token.address);
 
         // Validate oracle
-        e.invoke_contract(
+        let _: u128 = e.invoke_contract(
             &get_oracle_registry(&e),
             &Symbol::new(&e, "get_price"),
             Vec::from_array(&e, [token.symbol.to_val()]),
         );
 
         set_token_whitelist(&e, &token);
+
+        let mut token_vec = get_token_whitelist_vec(&e);
+        token_vec.push_back(token.address.clone());
+        set_token_whitelist_vec(&e, &token_vec);
+
+        // Setup reserve
+        let reserve = get_reserve(&e, &token.address);
+        put_reserve(&e, &token.address, &reserve);
 
         FundEvents::new(&e).whitelist_token(admin, token.address, token.symbol);
     }
@@ -1177,21 +1122,34 @@ impl AdminInterface for InsuranceFund {
         admin.require_auth();
         require_admin(&e, &admin);
 
-        let token = get_token_whitelist(&e, &token);
+        let whitelist_token = get_token_whitelist(&e, &token);
 
         // Error if not inactive token
-        if token.active {
+        if whitelist_token.active {
             panic_with_error!(&e, InsuranceFundError::AdminNotSet);
         }
 
-        let reserve = get_reserve(&e, &token.address);
+        let reserve = get_reserve(&e, &whitelist_token.address);
 
         // Error if reserve has not been depleted yet
         if reserve.balance != 0 {
             panic_with_error!(&e, InsuranceFundError::AdminNotSet);
         }
 
-        FundEvents::new(&e).remove_whitelist_token(admin, token.address, reserve.balance);
+        remove_token_whitelist(&e, &whitelist_token.address);
+
+        let mut token_vec = get_token_whitelist_vec(&e);
+
+        for i in 0..token_vec.len() {
+            if let Some(existing) = token_vec.get(i) {
+                if existing == whitelist_token.address {
+                    token_vec.remove_unchecked(i);
+                }
+            }
+        }
+        set_token_whitelist_vec(&e, &token_vec);
+
+        FundEvents::new(&e).remove_whitelist_token(admin, whitelist_token.address, reserve.balance);
     }
 
     //    _______     __       ____  ____   ________  _______  ________
@@ -1260,6 +1218,84 @@ impl AdminInterface for InsuranceFund {
 
     fn get_is_killed_withdraw(e: Env) -> bool {
         get_is_killed_withdraw(&e)
+    }
+}
+
+// The `UpgradeableContract` trait provides the interface for upgrading the contract.
+#[contractimpl]
+impl UpgradeableContract for InsuranceFund {
+    // Returns the version of the contract.
+    //
+    // # Returns
+    //
+    // The version of the contract as a u32.
+    fn version() -> u32 {
+        100
+    }
+
+    // Commits a new wasm hash for a future upgrade.
+    // The upgrade will be available through `apply_upgrade` after the standard upgrade delay
+    // unless the system is in emergency mode.
+    //
+    // # Arguments
+    //
+    // * `admin` - The address of the admin.
+    // * `new_wasm_hash` - The new wasm hash to commit.
+    fn commit_upgrade(e: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
+        commit_upgrade(&e, &new_wasm_hash);
+        UpgradeEvents::new(&e).commit_upgrade(Vec::from_array(&e, [new_wasm_hash.clone()]));
+    }
+
+    // Applies the committed upgrade.
+    //
+    // # Arguments
+    //
+    // * `admin` - The address of the admin.
+    fn apply_upgrade(e: Env, admin: Address) -> BytesN<32> {
+        admin.require_auth();
+        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
+        let new_wasm_hash = apply_upgrade(&e);
+        UpgradeEvents::new(&e).apply_upgrade(Vec::from_array(&e, [new_wasm_hash.clone()]));
+        new_wasm_hash
+    }
+
+    // Reverts the committed upgrade.
+    // This can be used to cancel a previously committed upgrade.
+    // The upgrade will be canceled only if it has not been applied yet.
+    // If the upgrade has already been applied, it cannot be reverted.
+    //
+    // # Arguments
+    //
+    // * `admin` - The address of the admin.
+    fn revert_upgrade(e: Env, admin: Address) {
+        admin.require_auth();
+        AccessControl::new(&e).assert_address_has_role(&admin, &Role::Admin);
+        revert_upgrade(&e);
+        UpgradeEvents::new(&e).revert_upgrade();
+    }
+
+    // Sets the emergency mode.
+    // When the emergency mode is set to true, the contract will allow instant upgrades without the delay.
+    // This is useful in case of critical issues that need to be fixed immediately.
+    // When the emergency mode is set to false, the contract will require the standard upgrade delay.
+    // The emergency mode can only be set by the emergency admin.
+    //
+    // # Arguments
+    //
+    // * `emergency_admin` - The address of the emergency admin.
+    // * `value` - The value to set the emergency mode to.
+    fn set_emergency_mode(e: Env, emergency_admin: Address, value: bool) {
+        emergency_admin.require_auth();
+        AccessControl::new(&e).assert_address_has_role(&emergency_admin, &Role::EmergencyAdmin);
+        set_emergency_mode(&e, &value);
+        AccessControlEvents::new(&e).set_emergency_mode(value);
+    }
+
+    // Returns the emergency mode flag value.
+    fn get_emergency_mode(e: Env) -> bool {
+        get_emergency_mode(&e)
     }
 }
 

--- a/contracts/insurance_fund/src/errors.rs
+++ b/contracts/insurance_fund/src/errors.rs
@@ -30,6 +30,7 @@ pub enum InsuranceFundError {
     PayInsuranceClaimFailed = 25,
     UnsupportedToken = 26,
     TokenAlreadyDeleted = 27,
+    InvalidOracle = 28,
 
     // paused ops
     FundDepositKilled = 30,

--- a/contracts/insurance_fund/src/errors.rs
+++ b/contracts/insurance_fund/src/errors.rs
@@ -28,6 +28,8 @@ pub enum InsuranceFundError {
     CostBasisUnderflow = 23,
     QueryPoolFailed = 24,
     PayInsuranceClaimFailed = 25,
+    UnsupportedToken = 26,
+    TokenAlreadyDeleted = 27,
 
     // paused ops
     FundDepositKilled = 30,

--- a/contracts/insurance_fund/src/events.rs
+++ b/contracts/insurance_fund/src/events.rs
@@ -61,6 +61,10 @@ pub(crate) trait InsuranceFundEvents {
         new_status: bool,
     );
 
+    fn sync(&self, sender: Address, token: Address, amount: i128);
+
+    fn skim(&self, sender: Address, token: Address, amount: i128);
+
     //    _______     __       ____  ____   ________  _______  ________
     //   |   __ "\   /""\     ("  _||_ " | /"       )/"     "||"      "\
     //   (. |__) :) /    \    |   (  ) : |(:   \___/(: ______)(.  ___  :)
@@ -167,6 +171,18 @@ impl InsuranceFundEvents for Events {
             ),
             (),
         );
+    }
+
+    fn sync(&self, user: Address, token: Address, amount: i128) {
+        self.env()
+            .events()
+            .publish((Symbol::new(self.env(), "sync"), token), (user, amount));
+    }
+
+    fn skim(&self, user: Address, token: Address, amount: i128) {
+        self.env()
+            .events()
+            .publish((Symbol::new(self.env(), "skim"), token), (user, amount));
     }
 
     //    _______     __       ____  ____   ________  _______  ________

--- a/contracts/insurance_fund/src/events.rs
+++ b/contracts/insurance_fund/src/events.rs
@@ -41,7 +41,7 @@ pub(crate) trait InsuranceFundEvents {
 
     fn collect_premium(&self, sender: Address, token: Address, amount: u128);
 
-    fn whitelist_token(&self, sender: Address, token: Address);
+    fn whitelist_token(&self, sender: Address, token: Address, symbol: Symbol);
 
     fn remove_whitelist_token(&self, sender: Address, token: Address, reserve_amount: u128);
 
@@ -52,7 +52,7 @@ pub(crate) trait InsuranceFundEvents {
         new_insurance: u128,
     );
 
-    fn premium_whitelist_status_updated(
+    fn premium_payer_status_updated(
         &self,
         ts: u64,
         admin: Address,
@@ -132,10 +132,11 @@ impl InsuranceFundEvents for Events {
         );
     }
 
-    fn whitelist_token(&self, sender: Address, token: Address) {
-        self.env()
-            .events()
-            .publish((Symbol::new(self.env(), "whitelist_token"), sender), token);
+    fn whitelist_token(&self, sender: Address, token: Address, symbol: Symbol) {
+        self.env().events().publish(
+            (Symbol::new(self.env(), "whitelist_token"), sender),
+            (token, symbol),
+        );
     }
 
     fn remove_whitelist_token(&self, sender: Address, token: Address, reserve_amount: u128) {
@@ -157,7 +158,7 @@ impl InsuranceFundEvents for Events {
         );
     }
 
-    fn premium_whitelist_status_updated(
+    fn premium_payer_status_updated(
         &self,
         ts: u64,
         admin: Address,
@@ -167,7 +168,7 @@ impl InsuranceFundEvents for Events {
     ) {
         self.env().events().publish(
             (
-                Symbol::new(self.env(), "premium_whitelist_status_updated"),
+                Symbol::new(self.env(), "premium_payer_status_updated"),
                 ts,
                 admin,
                 user,

--- a/contracts/insurance_fund/src/events.rs
+++ b/contracts/insurance_fund/src/events.rs
@@ -29,6 +29,7 @@ pub(crate) trait InsuranceFundEvents {
     fn if_stake_record(
         &self,
         user: Address,
+        token: Address,
         action: StakeAction,
         amount: u128,
         insurance_vault_amount_before: u128,
@@ -38,7 +39,11 @@ pub(crate) trait InsuranceFundEvents {
         total_if_shares_after: u128,
     );
 
-    fn collect_premium(&self, sender: Address, amount: u128);
+    fn collect_premium(&self, sender: Address, token: Address, amount: u128);
+
+    fn whitelist_token(&self, sender: Address, token: Address);
+
+    fn remove_whitelist_token(&self, sender: Address, token: Address, reserve_amount: u128);
 
     fn sync_optimal_insurance(
         &self,
@@ -89,6 +94,7 @@ impl InsuranceFundEvents for Events {
     fn if_stake_record(
         &self,
         user: Address,
+        token: Address,
         action: StakeAction,
         amount: u128,
         insurance_vault_amount_before: u128,
@@ -110,10 +116,24 @@ impl InsuranceFundEvents for Events {
         );
     }
 
-    fn collect_premium(&self, sender: Address, amount: u128) {
+    fn collect_premium(&self, sender: Address, token: Address, amount: u128) {
+        self.env().events().publish(
+            (Symbol::new(self.env(), "collect_premium"), sender),
+            (token, amount),
+        );
+    }
+
+    fn whitelist_token(&self, sender: Address, token: Address) {
         self.env()
             .events()
-            .publish((Symbol::new(self.env(), "collect_premium"), sender), amount);
+            .publish((Symbol::new(self.env(), "whitelist_token"), sender), token);
+    }
+
+    fn remove_whitelist_token(&self, sender: Address, token: Address, reserve_amount: u128) {
+        self.env().events().publish(
+            (Symbol::new(self.env(), "remove_whitelist_token"), sender),
+            (token, reserve_amount),
+        );
     }
 
     fn sync_optimal_insurance(

--- a/contracts/insurance_fund/src/events.rs
+++ b/contracts/insurance_fund/src/events.rs
@@ -108,7 +108,12 @@ impl InsuranceFundEvents for Events {
         total_if_shares_after: u128,
     ) {
         self.env().events().publish(
-            (Symbol::new(self.env(), "if_stake_record"), user, action),
+            (
+                Symbol::new(self.env(), "if_stake_record"),
+                user,
+                token,
+                action,
+            ),
             (
                 amount,
                 insurance_vault_amount_before,

--- a/contracts/insurance_fund/src/events.rs
+++ b/contracts/insurance_fund/src/events.rs
@@ -26,17 +26,17 @@ pub(crate) trait InsuranceFundEvents {
     // |.  \    /:  | /   /  \\  \  /\  |\|    \    \ |
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
-    fn if_stake_record(
+    fn insurance_stake_record(
         &self,
         user: Address,
         token: Address,
         action: StakeAction,
         amount: u128,
-        insurance_vault_amount_before: u128,
-        if_shares_before: u128,
-        total_if_shares_before: u128,
-        if_shares_after: u128,
-        total_if_shares_after: u128,
+        reserve_balance_before: u128,
+        stake_shares_before: u128,
+        total_shares_before: u128,
+        stake_shares_after: u128,
+        total_shares_after: u128,
     );
 
     fn collect_premium(&self, sender: Address, token: Address, amount: u128);
@@ -95,32 +95,32 @@ impl InsuranceFundEvents for Events {
     // |.  \    /:  | /   /  \\  \  /\  |\|    \    \ |
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
-    fn if_stake_record(
+    fn insurance_stake_record(
         &self,
         user: Address,
         token: Address,
         action: StakeAction,
         amount: u128,
-        insurance_vault_amount_before: u128,
-        if_shares_before: u128,
-        total_if_shares_before: u128,
-        if_shares_after: u128,
-        total_if_shares_after: u128,
+        reserve_balance_before: u128,
+        stake_shares_before: u128,
+        total_shares_before: u128,
+        stake_shares_after: u128,
+        total_shares_after: u128,
     ) {
         self.env().events().publish(
             (
-                Symbol::new(self.env(), "if_stake_record"),
+                Symbol::new(self.env(), "insurance_stake_record"),
                 user,
                 token,
                 action,
             ),
             (
                 amount,
-                insurance_vault_amount_before,
-                if_shares_before,
-                total_if_shares_before,
-                if_shares_after,
-                total_if_shares_after,
+                reserve_balance_before,
+                stake_shares_before,
+                total_shares_before,
+                stake_shares_after,
+                total_shares_after,
             ),
         );
     }

--- a/contracts/insurance_fund/src/interest.rs
+++ b/contracts/insurance_fund/src/interest.rs
@@ -1,27 +1,60 @@
 use soroban_fixed_point_math::FixedPoint;
-use utils::constant::{PERCENTAGE_PRECISION, PERCENTAGE_PRECISION_I64};
+use soroban_sdk::{Env, Symbol, Vec};
+use utils::{
+    constant::{PERCENTAGE_PRECISION, PERCENTAGE_PRECISION_I64},
+    state::oracle_registry::{HistoricalOracleData, OracleValidity},
+};
+
+use crate::storage::{get_oracle_registry, get_reserve};
+
+pub fn calculate_total_reserve_value(e: &Env) -> u128 {
+    let token_whitelist = get_whitelist_tokens(&e);
+
+    let total_reserve_value: u128 = 0;
+
+    for i in 0..token_whitelist.len() {
+        let token = token_whitelist.get(i).unwrap();
+
+        let reserve = get_reserve(&e, &token.address);
+
+        // Fetch price
+        let (historical_oracle_data, oracle_validity): (HistoricalOracleData, OracleValidity) = e
+            .invoke_contract(
+                &get_oracle_registry(&e),
+                &Symbol::new(&e, "get_price"),
+                Vec::from_array(&e, [token.symbol.to_val()]),
+            );
+
+        let reserve_value = reserve
+            .balance
+            .saturating_mul(historical_oracle_data.last_oracle_price_twap);
+
+        total_reserve_value = total_reserve_value.saturating_add(reserve_value);
+    }
+
+    total_reserve_value
+}
 
 // Calculates the utilization percentage of the insurance fund.
 //
 // # Arguments
 //
-// * `insurance_vault_amount` - The current balance in the insurance vault, in fixed-point units.
+// * `total_reserve_value` - The current balance in the insurance vault, in fixed-point units.
 // * `optimal_insurance` - The target or optimal coverage amount, in fixed-point units.
 //
 // # Returns
 //
 // * The utilization percentage as a fixed-point `u32` (e.g. 10_000_000 = 100%).
 //   Returns 0 if either input is zero. The result is scaled by `PERCENTAGE_PRECISION`.
-pub fn calculate_utilization(insurance_vault_amount: u128, optimal_insurance: u128) -> u32 {
-    if insurance_vault_amount == 0 || optimal_insurance == 0 {
+pub fn calculate_utilization(total_reserve_value: u128, optimal_insurance: u128) -> u32 {
+    if total_reserve_value == 0 || optimal_insurance == 0 {
         return 0;
     }
 
     // is this safe to cast u128 down to i32?
-    insurance_vault_amount
+    total_reserve_value
         .fixed_div_floor(optimal_insurance, PERCENTAGE_PRECISION)
         .unwrap_or(0) as u32
-    //  result.min(u32::MAX as u128) as u32
 }
 
 // Calculates the interest rate based on utilization using a two-slope model.

--- a/contracts/insurance_fund/src/interest.rs
+++ b/contracts/insurance_fund/src/interest.rs
@@ -1,3 +1,6 @@
+use crate::storage::{
+    get_oracle_registry, get_reserve, get_token_whitelist, get_token_whitelist_vec,
+};
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{Env, Symbol, Vec};
 use utils::{
@@ -5,24 +8,23 @@ use utils::{
     state::oracle_registry::{HistoricalOracleData, OracleValidity},
 };
 
-use crate::storage::{get_oracle_registry, get_reserve};
-
 pub fn calculate_total_reserve_value(e: &Env) -> u128 {
-    let token_whitelist = get_whitelist_tokens(&e);
+    let tokens = get_token_whitelist_vec(&e);
 
-    let total_reserve_value: u128 = 0;
+    let mut total_reserve_value: u128 = 0;
 
-    for i in 0..token_whitelist.len() {
-        let token = token_whitelist.get(i).unwrap();
+    for i in 0..tokens.len() {
+        let token = tokens.get(i).unwrap();
+        let whitelist_token = get_token_whitelist(e, &token);
 
-        let reserve = get_reserve(&e, &token.address);
+        let reserve = get_reserve(&e, &whitelist_token.address);
 
         // Fetch price
         let (historical_oracle_data, oracle_validity): (HistoricalOracleData, OracleValidity) = e
             .invoke_contract(
                 &get_oracle_registry(&e),
                 &Symbol::new(&e, "get_price"),
-                Vec::from_array(&e, [token.symbol.to_val()]),
+                Vec::from_array(&e, [whitelist_token.symbol.to_val()]),
             );
 
         let reserve_value = reserve

--- a/contracts/insurance_fund/src/interest.rs
+++ b/contracts/insurance_fund/src/interest.rs
@@ -1,8 +1,9 @@
-use crate::storage::{
-    get_oracle_registry, get_reserve, get_token_whitelist, get_token_whitelist_vec,
+use crate::{
+    errors::InsuranceFundError,
+    storage::{get_oracle_registry, get_reserve, get_token_whitelist, get_token_whitelist_vec},
 };
 use soroban_fixed_point_math::FixedPoint;
-use soroban_sdk::{Env, Symbol, Vec};
+use soroban_sdk::{panic_with_error, Env, Symbol, Vec};
 use utils::{
     constant::{PERCENTAGE_PRECISION, PERCENTAGE_PRECISION_I64},
     state::oracle_registry::{HistoricalOracleData, OracleValidity},
@@ -26,6 +27,11 @@ pub fn calculate_total_reserve_value(e: &Env) -> u128 {
                 &Symbol::new(&e, "get_price"),
                 Vec::from_array(&e, [whitelist_token.symbol.to_val()]),
             );
+
+        // Check oracle validity
+        if oracle_validity != OracleValidity::Valid {
+            panic_with_error!(e, InsuranceFundError::InvalidOracle);
+        }
 
         let reserve_value = reserve
             .balance

--- a/contracts/insurance_fund/src/interface.rs
+++ b/contracts/insurance_fund/src/interface.rs
@@ -1,6 +1,8 @@
 use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{Address, Env, Vec};
+use utils::state::token::DetailedToken;
 
-use crate::stake::Stake;
+use crate::{reserve::InsuranceFundReserve, stake::Stake};
 
 pub trait InsuranceFundTrait {
     fn initialize(
@@ -11,6 +13,7 @@ pub trait InsuranceFundTrait {
         pool_router: Address,
         premium_token: Address,
         whitelisted_tokens: Vec<Address>,
+        oracle_registry: Address,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -59,11 +62,9 @@ pub trait InsuranceFundTrait {
 
     fn get_optimal_insurance(e: Env) -> u128;
 
-    fn get_total_shares(e: Env) -> u128;
+    fn get_reserve(e: Env, token: Address) -> InsuranceFundReserve;
 
-    fn get_share_base(e: Env) -> u128;
-
-    fn get_stake(e: Env, user: Address) -> Stake;
+    fn get_stake(e: Env, user: Address, token: Address) -> Stake;
 
     fn get_optimal_utilization(e: Env) -> u32;
 
@@ -101,6 +102,10 @@ pub trait AdminInterface {
 
     fn set_pool_router(e: Env, admin: Address, pool_router: Address);
     fn add_whitelist_token(e: Env, admin: Address, token: Address);
+
+    fn add_whitelist_token(e: Env, admin: Address, token: DetailedToken);
+
+    fn remove_whitelist_token(e: Env, admin: Address, token: DetailedToken);
 
     fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64);
 

--- a/contracts/insurance_fund/src/interface.rs
+++ b/contracts/insurance_fund/src/interface.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, Env, Symbol, Vec};
 
 use crate::stake::Stake;
 
@@ -7,8 +7,10 @@ pub trait InsuranceFundTrait {
         e: Env,
         admin: Address,
         emergency_admin: Address,
-        token: Address,
+        oracle_registry: Address,
         pool_router: Address,
+        premium_token: Address,
+        whitelisted_tokens: Vec<Address>,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -23,13 +25,13 @@ pub trait InsuranceFundTrait {
     // |.  \    /:  | /   /  \\  \  /\  |\|    \    \ |
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
-    fn deposit(e: Env, user: Address, amount: u128);
+    fn deposit(e: Env, user: Address, token: Address, amount: u128);
 
-    fn request_withdraw(e: Env, user: Address, amount: u128);
+    fn request_withdraw(e: Env, user: Address, token: Address, amount: u128);
 
-    fn cancel_request_withdraw(e: Env, user: Address);
+    fn cancel_request_withdraw(e: Env, user: Address, token: Address);
 
-    fn withdraw(e: Env, user: Address);
+    fn withdraw(e: Env, user: Address, token: Address);
 
     fn pay_premium(e: Env, sender: Address, amount: u128);
 
@@ -41,7 +43,9 @@ pub trait InsuranceFundTrait {
     // (:   _(  _|(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     //  \_______)  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
-    fn get_token(e: Env) -> Address;
+    fn get_whitelist_tokens(e: Env) -> Vec<Address>;
+
+    fn get_deletion_queue_tokens(e: Env) -> Vec<Address>;
 
     fn get_pool_router(e: Env) -> Address;
 
@@ -90,6 +94,7 @@ pub trait AdminInterface {
     // (_______/  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
     fn set_pool_router(e: Env, admin: Address, pool_router: Address);
+    fn add_whitelist_token(e: Env, admin: Address, token: Address);
 
     fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64);
 
@@ -103,6 +108,8 @@ pub trait AdminInterface {
     );
 
     fn set_whitelist_status(e: Env, admin: Address, address: Address, status: bool);
+
+    fn remove_whitelist_token(e: Env, admin: Address, token: Address);
 
     //    _______     __       ____  ____   ________  _______  ________
     //   |   __ "\   /""\     ("  _||_ " | /"       )/"     "||"      "\

--- a/contracts/insurance_fund/src/interface.rs
+++ b/contracts/insurance_fund/src/interface.rs
@@ -11,7 +11,6 @@ pub trait InsuranceFundTrait {
         oracle_registry: Address,
         pool_router: Address,
         premium_token: Address,
-        whitelisted_tokens: Vec<Address>,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -100,7 +99,7 @@ pub trait AdminInterface {
 
     fn sync_optimal_insurance(e: Env, admin: Address);
 
-    fn resolve_liquidity_deficit(e: Env, admin: Address, token: Address, asset: Symbol);
+    fn file_claim(e: Env, admin: Address, token: Address, asset: Symbol);
 
     //   ________  _______  ___________  ___________  _______   _______    ________
     //  /"       )/"     "|("     _   ")("     _   ")/"     "| /"      \  /"       )

--- a/contracts/insurance_fund/src/interface.rs
+++ b/contracts/insurance_fund/src/interface.rs
@@ -35,6 +35,12 @@ pub trait InsuranceFundTrait {
 
     fn pay_premium(e: Env, sender: Address, amount: u128);
 
+    // Sync token balances with reserves
+    fn sync(e: Env, sender: Address, token: Address);
+
+    // Skim excess token balances
+    fn skim(e: Env, sender: Address, token: Address);
+
     //   _______    _______  ___________  ___________  _______   _______    ________
     //  /" _   "|  /"     "|("     _   ")("     _   ")/"     "| /"      \  /"       )
     // (: ( \___) (: ______) )__/  \\__/  )__/  \\__/(: ______)|:        |(:   \___/

--- a/contracts/insurance_fund/src/interface.rs
+++ b/contracts/insurance_fund/src/interface.rs
@@ -1,7 +1,6 @@
 use soroban_sdk::{Address, Env, Symbol, Vec};
-use soroban_sdk::{Address, Env, Vec};
-use utils::state::token::DetailedToken;
 
+use crate::storage::WhitelistToken;
 use crate::{reserve::InsuranceFundReserve, stake::Stake};
 
 pub trait InsuranceFundTrait {
@@ -13,7 +12,6 @@ pub trait InsuranceFundTrait {
         pool_router: Address,
         premium_token: Address,
         whitelisted_tokens: Vec<Address>,
-        oracle_registry: Address,
         unstaking_period: u64,
         optimal_utilization: u32,
         base_rate: i32,
@@ -52,19 +50,33 @@ pub trait InsuranceFundTrait {
     // (:   _(  _|(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     //  \_______)  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
-    fn get_whitelist_tokens(e: Env) -> Vec<Address>;
+    // Addresses
 
-    fn get_deletion_queue_tokens(e: Env) -> Vec<Address>;
+    fn get_oracle_registry(e: Env) -> Address;
 
     fn get_pool_router(e: Env) -> Address;
+
+    fn get_premium_token(e: Env) -> Address;
+
+    // Access
+
+    fn get_premium_payer_status(e: Env, address: Address) -> bool;
+
+    fn get_token_whitelist(e: Env, token: Address) -> WhitelistToken;
+
+    // Config
 
     fn get_unstaking_period(e: Env) -> u64;
 
     fn get_optimal_insurance(e: Env) -> u128;
 
+    // Reserve
+
     fn get_reserve(e: Env, token: Address) -> InsuranceFundReserve;
 
     fn get_stake(e: Env, user: Address, token: Address) -> Stake;
+
+    // Interest
 
     fn get_optimal_utilization(e: Env) -> u32;
 
@@ -75,8 +87,6 @@ pub trait InsuranceFundTrait {
     fn get_base_rate(e: Env) -> i32;
 
     fn get_rate_slopes(e: Env) -> (u32, u32);
-
-    fn get_premium_whitelist_status(e: Env, address: Address) -> bool;
 }
 
 pub trait AdminInterface {
@@ -90,7 +100,7 @@ pub trait AdminInterface {
 
     fn sync_optimal_insurance(e: Env, admin: Address);
 
-    fn resolve_liquidity_deficit(e: Env, admin: Address, asset: Symbol);
+    fn resolve_liquidity_deficit(e: Env, admin: Address, token: Address, asset: Symbol);
 
     //   ________  _______  ___________  ___________  _______   _______    ________
     //  /"       )/"     "|("     _   ")("     _   ")/"     "| /"      \  /"       )
@@ -100,12 +110,11 @@ pub trait AdminInterface {
     //  /" \   :)(:      "|    \:  |        \:  |   (:      "||:  __   \  /" \   :)
     // (_______/  \_______)     \__|         \__|    \_______)|__|  \___)(_______/
 
+    fn set_oracle_registry(e: Env, admin: Address, oracle_registry: Address);
+
     fn set_pool_router(e: Env, admin: Address, pool_router: Address);
-    fn add_whitelist_token(e: Env, admin: Address, token: Address);
 
-    fn add_whitelist_token(e: Env, admin: Address, token: DetailedToken);
-
-    fn remove_whitelist_token(e: Env, admin: Address, token: DetailedToken);
+    fn set_premium_payer_status(e: Env, admin: Address, payer: Address, status: bool);
 
     fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64);
 
@@ -118,7 +127,11 @@ pub trait AdminInterface {
         rate_slope_b: u32,
     );
 
-    fn set_whitelist_status(e: Env, admin: Address, address: Address, status: bool);
+    // Token whitelist
+
+    fn add_token_whitelist(e: Env, admin: Address, token: WhitelistToken);
+
+    fn set_token_whitelist_status(e: Env, admin: Address, token: Address, status: bool);
 
     fn remove_whitelist_token(e: Env, admin: Address, token: Address);
 
@@ -130,17 +143,14 @@ pub trait AdminInterface {
     //  /|__/ \  /   /  \\  \  /\\ __ //\  /" \   :)(:      "||:       :)
     // (_______)(___/    \___)(__________)(_______/  \_______)(________/
 
-    // Stop staking instantly
     fn kill_deposit(e: Env, admin: Address);
     fn kill_request_withdraw(e: Env, admin: Address);
     fn kill_withdraw(e: Env, admin: Address);
 
-    // Resume staking
     fn unkill_deposit(e: Env, admin: Address);
     fn unkill_request_withdraw(e: Env, admin: Address);
     fn unkill_withdraw(e: Env, admin: Address);
 
-    // Get killswitch status
     fn get_is_killed_deposit(e: Env) -> bool;
     fn get_is_killed_request_withdraw(e: Env) -> bool;
     fn get_is_killed_withdraw(e: Env) -> bool;

--- a/contracts/insurance_fund/src/lib.rs
+++ b/contracts/insurance_fund/src/lib.rs
@@ -5,6 +5,7 @@ pub mod errors;
 mod events;
 mod interest;
 mod interface;
+mod reserve;
 mod stake;
 mod storage;
 mod test;

--- a/contracts/insurance_fund/src/reserve.rs
+++ b/contracts/insurance_fund/src/reserve.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::storage::put_reserve;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -33,40 +35,42 @@ impl InsuranceFundReserve {
         }
     }
 
-    pub fn deposit(self, amount: u128, now: u64) -> Self {
-        InsuranceFundReserve {
-            balance: self.balance.saturating_add(amount),
-            total_deposits: self.total_deposits.saturating_add(amount),
-            last_update_ts: now,
-            ..self
-        }
+    pub fn save(&mut self, e: &Env) {
+        put_reserve(e, &self.token, &self);
     }
 
-    pub fn withdraw(self, amount: u128, now: u64) -> Self {
-        InsuranceFundReserve {
-            balance: self.balance.saturating_sub(amount),
-            total_withdrawals: self.total_withdrawals.saturating_add(amount),
-            last_update_ts: now,
-            ..self
-        }
+    pub fn deposit(&mut self, amount: u128, now: u64) {
+        self.balance = self.balance.saturating_add(amount);
+        self.total_deposits = self.total_deposits.saturating_add(amount);
+        self.last_update_ts = now;
     }
 
-    pub fn claim(self, amount: u128, now: u64) -> Self {
-        InsuranceFundReserve {
-            balance: self.balance.saturating_sub(amount),
-            total_claims: self.total_claims.saturating_add(amount),
-            last_claim: amount,
-            last_claim_ts: now,
-            last_update_ts: now,
-            ..self
-        }
+    pub fn withdraw(&mut self, amount: u128, now: u64) {
+        self.balance = self.balance.saturating_sub(amount);
+        self.total_withdrawals = self.total_withdrawals.saturating_add(amount);
+        self.last_update_ts = now;
     }
 
-    pub fn update_balance(self, amount: u128, now: u64) -> Self {
-        InsuranceFundReserve {
-            balance: amount,
-            last_update_ts: now,
-            ..self
-        }
+    pub fn claim(&mut self, amount: u128, now: u64) {
+        self.balance = self.balance.saturating_sub(amount);
+        self.total_claims = self.total_claims.saturating_add(amount);
+        self.last_claim = amount;
+        self.last_claim_ts = now;
+        self.last_update_ts = now;
+    }
+
+    pub fn update_balance(&mut self, amount: u128, now: u64) {
+        self.balance = amount;
+        self.last_update_ts = now;
+    }
+
+    pub fn add_total_shares(&mut self, amount: u128, now: u64) {
+        self.total_shares = self.total_shares.saturating_add(amount);
+        self.last_update_ts = now;
+    }
+
+    pub fn remove_total_shares(&mut self, amount: u128, now: u64) {
+        self.total_shares = self.total_shares.saturating_sub(amount);
+        self.last_update_ts = now;
     }
 }

--- a/contracts/insurance_fund/src/reserve.rs
+++ b/contracts/insurance_fund/src/reserve.rs
@@ -1,0 +1,72 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InsuranceFundReserve {
+    pub token: Address,
+    pub balance: u128, // the current token balance of the reserve.
+    // shares
+    pub total_shares: u128, // the total amount of issued shares.
+    pub shares_base: u128,  // exponent for lp shares (for rebasing).
+    // metrics
+    pub total_deposits: u128, // the total amount of deposits made into this reserve.
+    pub total_withdrawals: u128, // the total amount of payouts made from this reserve.
+    pub total_claims: u128,
+    pub last_claim: u128,    // the token amount of the last claim.
+    pub last_claim_ts: u64,  // the timestamp of the last claim.
+    pub last_update_ts: u64, // the timestamp of the last reserve update.
+}
+
+impl InsuranceFundReserve {
+    pub fn new(token: Address, now: u64) -> Self {
+        InsuranceFundReserve {
+            token,
+            balance: 0,
+            total_deposits: 0,
+            total_withdrawals: 0,
+            total_claims: 0,
+            total_shares: 0,
+            shares_base: 0,
+            last_claim: 0,
+            last_claim_ts: 0,
+            last_update_ts: now,
+        }
+    }
+
+    pub fn deposit(self, amount: u128, now: u64) -> Self {
+        InsuranceFundReserve {
+            balance: self.balance.saturating_add(amount),
+            total_deposits: self.total_deposits.saturating_add(amount),
+            last_update_ts: now,
+            ..self
+        }
+    }
+
+    pub fn withdraw(self, amount: u128, now: u64) -> Self {
+        InsuranceFundReserve {
+            balance: self.balance.saturating_sub(amount),
+            total_withdrawals: self.total_withdrawals.saturating_add(amount),
+            last_update_ts: now,
+            ..self
+        }
+    }
+
+    pub fn claim(self, amount: u128, now: u64) -> Self {
+        InsuranceFundReserve {
+            balance: self.balance.saturating_sub(amount),
+            total_claims: self.total_claims.saturating_add(amount),
+            last_claim: amount,
+            last_claim_ts: now,
+            last_update_ts: now,
+            ..self
+        }
+    }
+
+    pub fn update_balance(self, amount: u128, now: u64) -> Self {
+        InsuranceFundReserve {
+            balance: amount,
+            last_update_ts: now,
+            ..self
+        }
+    }
+}

--- a/contracts/insurance_fund/src/stake.rs
+++ b/contracts/insurance_fund/src/stake.rs
@@ -20,59 +20,65 @@ pub enum StakeAction {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stake {
+    pub user: Address,
     pub token: Address,                     //
-    pub if_shares: u128,                    // the number of shares the user owns.
+    pub shares: u128,                       // the number of shares the user owns.
     pub last_withdraw_request_shares: u128, //
-    pub if_base: u128, // the exponent for if_shares decimal places (for rebase).
-    pub last_withdraw_request_value: u128, // the token amount of the last user withdrawal request.
+    pub base: u128,                         // the exponent for shares decimal places (for rebase).
+    pub last_withdraw_request_value: u128,  // the token amount of the last user withdrawal request.
     pub last_withdraw_request_ts: u64, // the timestamp when the user last requested a withdrawal.
-    pub cost_basis: u128, //
+    pub cost_basis: u128,              //
 }
 
 impl Stake {
-    pub fn new(token: Address) -> Self {
+    pub fn new(user: Address, token: Address) -> Self {
         Stake {
+            user,
             token,
             last_withdraw_request_shares: 0,
             last_withdraw_request_value: 0,
             last_withdraw_request_ts: 0,
             cost_basis: 0,
-            if_base: 0,
-            if_shares: 0,
+            base: 0,
+            shares: 0,
         }
+    }
+
+    pub fn save(&mut self, e: &Env) {
+        save_stake(e, &self.user, &self.token, &self);
     }
 
     fn validate_base(&self, e: &Env) {
         let reserve = get_reserve(e, &self.token);
         validate!(
             e,
-            self.if_base == reserve.shares_base,
+            self.base == reserve.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
     }
 
-    pub fn checked_if_shares(&self, e: &Env) -> u128 {
+    pub fn checked_shares(&self, e: &Env) -> u128 {
         self.validate_base(e);
-        self.if_shares
+        self.shares
     }
 
-    pub fn unchecked_if_shares(&self) -> u128 {
-        self.if_shares
+    pub fn unchecked_shares(&self) -> u128 {
+        self.shares
     }
 
-    pub fn increase_if_shares(&mut self, e: &Env, delta: u128) {
+    pub fn increase_shares(&mut self, e: &Env, delta: u128) {
         self.validate_base(e);
-        self.if_shares = self.if_shares.saturating_add(delta);
+        self.shares = self.shares.saturating_add(delta);
     }
 
-    pub fn decrease_if_shares(&mut self, e: &Env, delta: u128) {
+    pub fn decrease_shares(&mut self, e: &Env, delta: u128) {
         self.validate_base(e);
-        self.if_shares = self.if_shares.saturating_sub(delta);
+        self.shares = self.shares.saturating_sub(delta);
     }
 
-    pub fn update_if_shares(&mut self, e: &Env, new_shares: u128) {
+    pub fn update_shares(&mut self, e: &Env, new_shares: u128) {
         self.validate_base(e);
-        self.if_shares = new_shares;
+        self.shares = new_shares;
     }
 }
 
@@ -83,7 +89,7 @@ pub fn get_stake(e: &Env, user: &Address, token: &Address) -> Stake {
             bump_persistent(e, &key);
             stake
         }
-        None => Stake::new(token.clone()),
+        None => Stake::new(user.clone(), token.clone()),
     };
 
     stake_info
@@ -117,9 +123,7 @@ pub fn save_stake(e: &Env, user: &Address, token: &Address, stake_info: &Stake) 
 //
 // # Side Effects
 // - Updates `total_shares` and `shares_base` in contract storage.
-pub fn apply_rebase_to_insurance_fund(e: &Env, token: &Address) {
-    let mut reserve = get_reserve(e, token);
-
+pub fn apply_rebase_to_insurance_fund(e: &Env, reserve: &mut InsuranceFundReserve) {
     if reserve.balance != 0 && reserve.balance < reserve.total_shares {
         let (expo_diff, rebase_divisor) =
             calculate_rebase_info(e, reserve.total_shares, reserve.balance);
@@ -131,8 +135,6 @@ pub fn apply_rebase_to_insurance_fund(e: &Env, token: &Address) {
     if reserve.balance != 0 && reserve.total_shares == 0 {
         reserve.total_shares = reserve.balance;
     }
-
-    put_reserve(e, token, &reserve);
 }
 
 // Applies a rebase to an individual stake's insurance fund shares to align with the global share base.
@@ -155,24 +157,24 @@ pub fn apply_rebase_to_insurance_fund(e: &Env, token: &Address) {
 pub fn apply_rebase_to_stake(e: &Env, stake: &mut Stake) {
     let reserve = get_reserve(e, &stake.token);
 
-    if reserve.shares_base != stake.if_base {
+    if reserve.shares_base != stake.base {
         //  "Rebase expo out of bounds"
         validate!(
             e,
-            reserve.shares_base > stake.if_base,
+            reserve.shares_base > stake.base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        let expo_diff = (reserve.shares_base - stake.if_base) as u32;
+        let expo_diff = (reserve.shares_base - stake.base) as u32;
 
         let rebase_divisor = (10_u128).pow(expo_diff);
 
-        stake.if_base = reserve.shares_base;
+        stake.base = reserve.shares_base;
 
-        let old_if_shares = stake.unchecked_if_shares();
-        let new_if_shares = old_if_shares.safe_div(e, rebase_divisor);
+        let old_shares = stake.unchecked_shares();
+        let new_shares = old_shares.safe_div(e, rebase_divisor);
 
-        stake.update_if_shares(e, new_if_shares);
+        stake.update_shares(e, new_shares);
 
         stake.last_withdraw_request_shares = stake
             .last_withdraw_request_shares
@@ -440,7 +442,7 @@ pub fn if_shares_lost_test() {
 
     let token = Address::generate(&setup.env);
 
-    let mut if_stake = Stake::new(token);
+    let mut if_stake = Stake::new(setup.admin, token);
     if_stake.update_if_shares(&setup.env, 100 * QUOTE_PRECISION);
     if_stake.last_withdraw_request_shares = 100 * QUOTE_PRECISION;
     if_stake.last_withdraw_request_value = 100 * QUOTE_PRECISION - 1;

--- a/contracts/insurance_fund/src/stake.rs
+++ b/contracts/insurance_fund/src/stake.rs
@@ -442,49 +442,50 @@ pub fn if_shares_lost_test() {
 
     let token = Address::generate(&setup.env);
 
+    let reserve = InsuranceFundReserve::new(token, setup.env.ledger().timestamp());
     let mut if_stake = Stake::new(setup.admin, token);
-    if_stake.update_if_shares(&setup.env, 100 * QUOTE_PRECISION);
+    if_stake.update_shares(&setup.env, 100 * QUOTE_PRECISION);
     if_stake.last_withdraw_request_shares = 100 * QUOTE_PRECISION;
     if_stake.last_withdraw_request_value = 100 * QUOTE_PRECISION - 1;
 
     let if_balance = 1000 * QUOTE_PRECISION;
 
     // unchanged balance
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 2);
 
     let if_balance = if_balance + 100 * QUOTE_PRECISION;
     total_shares += 100 * QUOTE_PRECISION;
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 2); // giving up $5 of gains
 
     let if_balance = if_balance - 100 * QUOTE_PRECISION;
     total_shares -= 100 * QUOTE_PRECISION;
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 2); // giving up $5 of gains
 
     // take back gain
     let if_balance = 1100 * QUOTE_PRECISION;
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 10_000_001); // giving up $10 of gains
 
     // doesnt matter if theres a loss
     if_stake.last_withdraw_request_value = 200 * QUOTE_PRECISION;
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 0);
     if_stake.last_withdraw_request_value = 100 * QUOTE_PRECISION - 1;
 
     // take back gain and total_if_shares alter w/o user alter
     let if_balance = 2100 * QUOTE_PRECISION;
     total_shares *= 2;
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 5_000_001); // giving up $5 of gains
 
     let if_balance = 2100 * QUOTE_PRECISION * 10;
 
     let expected_gain_if_no_loss = (if_balance * 100) / 2000;
     assert_eq!(expected_gain_if_no_loss, 1_050_000_000);
-    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, &reserve);
     assert_eq!(lost_shares, 90_909_092); // giving up $5 of gains
     assert_eq!(
         (9090908 * if_balance) / (total_shares - lost_shares)

--- a/contracts/insurance_fund/src/stake.rs
+++ b/contracts/insurance_fund/src/stake.rs
@@ -1,5 +1,6 @@
 use crate::errors::InsuranceFundError;
-use crate::storage::{get_shares_base, get_total_shares, set_shares_base, set_total_shares};
+use crate::reserve::InsuranceFundReserve;
+use crate::storage::get_reserve;
 use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::{contracttype, panic_with_error, Address, Env};
 use utils::bump::bump_persistent;
@@ -19,6 +20,7 @@ pub enum StakeAction {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stake {
+    pub token: Address,                     //
     pub if_shares: u128,                    // the number of shares the user owns.
     pub last_withdraw_request_shares: u128, //
     pub if_base: u128, // the exponent for if_shares decimal places (for rebase).
@@ -112,20 +114,19 @@ pub fn save_stake(e: &Env, key: &Address, stake_info: &Stake) {
 //
 // # Side Effects
 // - Updates `total_shares` and `shares_base` in contract storage.
-pub fn apply_rebase_to_insurance_fund(e: &Env, insurance_vault_amount: u128) {
-    let total_shares = get_total_shares(e);
-    let shares_base = get_shares_base(e);
+pub fn apply_rebase_to_insurance_fund(e: &Env, token: Address) {
+    let reserve = get_reserve(e, &token);
 
-    if insurance_vault_amount != 0 && insurance_vault_amount < total_shares {
+    if reserve.balance != 0 && reserve.balance < reserve.total_shares {
         let (expo_diff, rebase_divisor) =
-            calculate_rebase_info(e, total_shares, insurance_vault_amount);
+            calculate_rebase_info(e, reserve.total_shares, reserve.balance);
 
-        set_total_shares(e, &total_shares.safe_div(e, rebase_divisor));
-        set_shares_base(e, &shares_base.safe_add(e, expo_diff as u128));
+        set_total_shares(e, &reserve.total_shares.safe_div(e, rebase_divisor));
+        set_shares_base(e, &reserve.shares_base.safe_add(e, expo_diff as u128));
     }
 
-    if insurance_vault_amount != 0 && total_shares == 0 {
-        set_total_shares(e, &(insurance_vault_amount as u128));
+    if reserve.balance != 0 && reserve.total_shares == 0 {
+        set_total_shares(e, &(reserve.balance as u128));
     }
 }
 
@@ -147,21 +148,21 @@ pub fn apply_rebase_to_insurance_fund(e: &Env, insurance_vault_amount: u128) {
 // # Side Effects
 // - Mutates the `stake` struct in-place.
 pub fn apply_rebase_to_stake(e: &Env, stake: &mut Stake) {
-    let shares_base = get_shares_base(e);
+    let reserve = get_reserve(e, &stake.token);
 
-    if shares_base != stake.if_base {
+    if reserve.shares_base != stake.if_base {
         //  "Rebase expo out of bounds"
         validate!(
             e,
-            shares_base > stake.if_base,
+            reserve.shares_base > stake.if_base,
             InsuranceFundError::InvalidIFRebase
         );
 
-        let expo_diff = (shares_base - stake.if_base) as u32;
+        let expo_diff = (reserve.shares_base - stake.if_base) as u32;
 
         let rebase_divisor = (10_u128).pow(expo_diff);
 
-        stake.if_base = shares_base;
+        stake.if_base = reserve.shares_base;
 
         let old_if_shares = stake.unchecked_if_shares();
         let new_if_shares = old_if_shares.safe_div(e, rebase_divisor);
@@ -182,8 +183,7 @@ pub fn apply_rebase_to_stake(e: &Env, stake: &mut Stake) {
 // # Arguments
 // * `e` - Soroban environment reference.
 // * `amount` - Vault amount to convert.
-// * `total_if_shares` - Total outstanding insurance fund shares.
-// * `insurance_vault_amount` - Total assets in the insurance vault.
+// * `reserve` - .
 //
 // # Returns
 // - The number of shares that correspond to the input amount.
@@ -191,21 +191,16 @@ pub fn apply_rebase_to_stake(e: &Env, stake: &mut Stake) {
 // # Validation
 // - If `insurance_vault_amount == 0`, then `total_if_shares` must also be zero.
 // - Falls back to 1:1 minting when vault is empty.
-pub fn vault_amount_to_if_shares(
-    e: &Env,
-    amount: u128,
-    total_if_shares: u128,
-    insurance_vault_amount: u128,
-) -> u128 {
+pub fn reserve_amount_to_shares(e: &Env, amount: u128, reserve: InsuranceFundReserve) -> u128 {
     // relative to the entire pool + total amount minted
-    let n_shares = if insurance_vault_amount > 0 {
+    let n_shares = if reserve.balance > 0 {
         // assumes total_if_shares != 0 (in most cases) for nice result for user
-        amount.fixed_mul_floor(e, &total_if_shares, &insurance_vault_amount)
+        amount.fixed_mul_floor(e, &reserve.total_shares, &reserve.balance)
     } else {
         // must be case that total_if_shares == 0 for nice result for user
         validate!(
             e,
-            total_if_shares == 0,
+            reserve.total_shares == 0,
             InsuranceFundError::InvalidIFSharesDetected
         );
 
@@ -222,8 +217,7 @@ pub fn vault_amount_to_if_shares(
 // # Arguments
 // * `e` - Soroban environment reference.
 // * `n_shares` - Number of insurance fund shares to convert.
-// * `total_if_shares` - Total outstanding insurance fund shares.
-// * `insurance_vault_amount` - Total assets in the insurance vault.
+// * `reserve` -
 //
 // # Returns
 // - The proportional vault amount corresponding to the shares.
@@ -231,20 +225,17 @@ pub fn vault_amount_to_if_shares(
 // # Validation
 // - Ensures `n_shares <= total_if_shares`.
 // - Returns `0` if total shares are zero (vault is empty).
-pub fn if_shares_to_vault_amount(
-    e: &Env,
-    n_shares: u128,
-    total_if_shares: u128,
-    insurance_vault_amount: u128,
-) -> u128 {
+pub fn shares_to_reserve_amount(e: &Env, n_shares: u128, reserve: InsuranceFundReserve) -> u128 {
     validate!(
         e,
-        n_shares <= total_if_shares,
+        n_shares <= reserve.total_shares,
         InsuranceFundError::InvalidIFSharesDetected
     );
 
-    let amount = if total_if_shares > 0 {
-        insurance_vault_amount.fixed_mul_floor(e, &n_shares, &total_if_shares)
+    let amount = if reserve.total_shares > 0 {
+        reserve
+            .balance
+            .fixed_mul_floor(e, &n_shares, &reserve.total_shares)
     } else {
         0
     };
@@ -301,19 +292,19 @@ pub fn calculate_rebase_info(
 //
 // # Validation
 // - Ensures recalculated shares are not greater than the original request.
-pub fn calculate_if_shares_lost(e: &Env, stake: &Stake, insurance_vault_amount: u128) -> u128 {
-    let total_shares = get_total_shares(e);
-
+pub fn calculate_shares_lost(e: &Env, stake: &Stake, reserve: &InsuranceFundReserve) -> u128 {
     let n_shares = stake.last_withdraw_request_shares;
 
-    let amount = if_shares_to_vault_amount(e, n_shares, total_shares, insurance_vault_amount);
+    let amount = shares_to_reserve_amount(e, n_shares, total_shares, reserve.balance);
 
     let if_shares_lost = if amount > stake.last_withdraw_request_value {
-        let new_n_shares = vault_amount_to_if_shares(
+        let new_n_shares = reserve_amount_to_shares(
             e,
             stake.last_withdraw_request_value,
-            total_shares.saturating_sub(n_shares),
-            insurance_vault_amount.saturating_sub(stake.last_withdraw_request_value),
+            reserve.total_shares.saturating_sub(n_shares),
+            reserve
+                .balance
+                .saturating_sub(stake.last_withdraw_request_value),
         );
 
         validate!(
@@ -446,41 +437,41 @@ pub fn if_shares_lost_test() {
     let if_balance = 1000 * QUOTE_PRECISION;
 
     // unchanged balance
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 2);
 
     let if_balance = if_balance + 100 * QUOTE_PRECISION;
     total_shares += 100 * QUOTE_PRECISION;
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 2); // giving up $5 of gains
 
     let if_balance = if_balance - 100 * QUOTE_PRECISION;
     total_shares -= 100 * QUOTE_PRECISION;
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 2); // giving up $5 of gains
 
     // take back gain
     let if_balance = 1100 * QUOTE_PRECISION;
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 10_000_001); // giving up $10 of gains
 
     // doesnt matter if theres a loss
     if_stake.last_withdraw_request_value = 200 * QUOTE_PRECISION;
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 0);
     if_stake.last_withdraw_request_value = 100 * QUOTE_PRECISION - 1;
 
     // take back gain and total_if_shares alter w/o user alter
     let if_balance = 2100 * QUOTE_PRECISION;
     total_shares *= 2;
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 5_000_001); // giving up $5 of gains
 
     let if_balance = 2100 * QUOTE_PRECISION * 10;
 
     let expected_gain_if_no_loss = (if_balance * 100) / 2000;
     assert_eq!(expected_gain_if_no_loss, 1_050_000_000);
-    let lost_shares = calculate_if_shares_lost(&setup.env, &if_stake, if_balance);
+    let lost_shares = calculate_shares_lost(&setup.env, &if_stake, if_balance);
     assert_eq!(lost_shares, 90_909_092); // giving up $5 of gains
     assert_eq!(
         (9090908 * if_balance) / (total_shares - lost_shares)

--- a/contracts/insurance_fund/src/stake.rs
+++ b/contracts/insurance_fund/src/stake.rs
@@ -1,6 +1,6 @@
 use crate::errors::InsuranceFundError;
 use crate::reserve::InsuranceFundReserve;
-use crate::storage::get_reserve;
+use crate::storage::{get_reserve, put_reserve};
 use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::{contracttype, panic_with_error, Address, Env};
 use utils::bump::bump_persistent;
@@ -30,8 +30,9 @@ pub struct Stake {
 }
 
 impl Stake {
-    pub fn new() -> Self {
+    pub fn new(token: Address) -> Self {
         Stake {
+            token,
             last_withdraw_request_shares: 0,
             last_withdraw_request_value: 0,
             last_withdraw_request_ts: 0,
@@ -42,10 +43,10 @@ impl Stake {
     }
 
     fn validate_base(&self, e: &Env) {
-        let shares_base = get_shares_base(e);
+        let reserve = get_reserve(e, &self.token);
         validate!(
             e,
-            self.if_base == shares_base,
+            self.if_base == reserve.shares_base,
             InsuranceFundError::InvalidIFRebase
         );
     }
@@ -75,20 +76,22 @@ impl Stake {
     }
 }
 
-pub fn get_stake(e: &Env, key: &Address) -> Stake {
-    let stake_info = match e.storage().persistent().get::<_, Stake>(key) {
+pub fn get_stake(e: &Env, user: &Address, token: &Address) -> Stake {
+    let key = (user, token);
+    let stake_info = match e.storage().persistent().get::<_, Stake>(&key) {
         Some(stake) => {
             bump_persistent(e, &key);
             stake
         }
-        None => Stake::new(),
+        None => Stake::new(token.clone()),
     };
 
     stake_info
 }
 
-pub fn save_stake(e: &Env, key: &Address, stake_info: &Stake) {
-    e.storage().persistent().set(key, stake_info);
+pub fn save_stake(e: &Env, user: &Address, token: &Address, stake_info: &Stake) {
+    let key = (user, token);
+    e.storage().persistent().set(&key, stake_info);
     bump_persistent(e, &key);
 }
 
@@ -114,20 +117,22 @@ pub fn save_stake(e: &Env, key: &Address, stake_info: &Stake) {
 //
 // # Side Effects
 // - Updates `total_shares` and `shares_base` in contract storage.
-pub fn apply_rebase_to_insurance_fund(e: &Env, token: Address) {
-    let reserve = get_reserve(e, &token);
+pub fn apply_rebase_to_insurance_fund(e: &Env, token: &Address) {
+    let mut reserve = get_reserve(e, token);
 
     if reserve.balance != 0 && reserve.balance < reserve.total_shares {
         let (expo_diff, rebase_divisor) =
             calculate_rebase_info(e, reserve.total_shares, reserve.balance);
 
-        set_total_shares(e, &reserve.total_shares.safe_div(e, rebase_divisor));
-        set_shares_base(e, &reserve.shares_base.safe_add(e, expo_diff as u128));
+        reserve.total_shares = reserve.total_shares.safe_div(e, rebase_divisor);
+        reserve.shares_base = reserve.shares_base.safe_add(e, expo_diff as u128);
     }
 
     if reserve.balance != 0 && reserve.total_shares == 0 {
-        set_total_shares(e, &(reserve.balance as u128));
+        reserve.total_shares = reserve.balance;
     }
+
+    put_reserve(e, token, &reserve);
 }
 
 // Applies a rebase to an individual stake's insurance fund shares to align with the global share base.
@@ -191,7 +196,7 @@ pub fn apply_rebase_to_stake(e: &Env, stake: &mut Stake) {
 // # Validation
 // - If `insurance_vault_amount == 0`, then `total_if_shares` must also be zero.
 // - Falls back to 1:1 minting when vault is empty.
-pub fn reserve_amount_to_shares(e: &Env, amount: u128, reserve: InsuranceFundReserve) -> u128 {
+pub fn reserve_amount_to_shares(e: &Env, amount: u128, reserve: &InsuranceFundReserve) -> u128 {
     // relative to the entire pool + total amount minted
     let n_shares = if reserve.balance > 0 {
         // assumes total_if_shares != 0 (in most cases) for nice result for user
@@ -225,7 +230,7 @@ pub fn reserve_amount_to_shares(e: &Env, amount: u128, reserve: InsuranceFundRes
 // # Validation
 // - Ensures `n_shares <= total_if_shares`.
 // - Returns `0` if total shares are zero (vault is empty).
-pub fn shares_to_reserve_amount(e: &Env, n_shares: u128, reserve: InsuranceFundReserve) -> u128 {
+pub fn shares_to_reserve_amount(e: &Env, n_shares: u128, reserve: &InsuranceFundReserve) -> u128 {
     validate!(
         e,
         n_shares <= reserve.total_shares,
@@ -295,16 +300,19 @@ pub fn calculate_rebase_info(
 pub fn calculate_shares_lost(e: &Env, stake: &Stake, reserve: &InsuranceFundReserve) -> u128 {
     let n_shares = stake.last_withdraw_request_shares;
 
-    let amount = shares_to_reserve_amount(e, n_shares, total_shares, reserve.balance);
+    let amount = shares_to_reserve_amount(e, n_shares, reserve);
 
     let if_shares_lost = if amount > stake.last_withdraw_request_value {
         let new_n_shares = reserve_amount_to_shares(
             e,
             stake.last_withdraw_request_value,
-            reserve.total_shares.saturating_sub(n_shares),
-            reserve
-                .balance
-                .saturating_sub(stake.last_withdraw_request_value),
+            &(InsuranceFundReserve {
+                total_shares: reserve.total_shares.saturating_sub(n_shares),
+                balance: reserve
+                    .balance
+                    .saturating_sub(stake.last_withdraw_request_value),
+                ..reserve.clone()
+            }),
         );
 
         validate!(
@@ -421,6 +429,7 @@ pub fn basic_stake_if_test() {
 #[test]
 pub fn if_shares_lost_test() {
     use crate::testutils::Setup;
+    use soroban_sdk::testutils::Address;
     use utils::constant::QUOTE_PRECISION;
 
     let setup = Setup::default();
@@ -429,7 +438,9 @@ pub fn if_shares_lost_test() {
 
     let mut total_shares = 1000 * QUOTE_PRECISION;
 
-    let mut if_stake = Stake::new();
+    let token = Address::generate(&setup.env);
+
+    let mut if_stake = Stake::new(token);
     if_stake.update_if_shares(&setup.env, 100 * QUOTE_PRECISION);
     if_stake.last_withdraw_request_shares = 100 * QUOTE_PRECISION;
     if_stake.last_withdraw_request_value = 100 * QUOTE_PRECISION - 1;

--- a/contracts/insurance_fund/src/storage.rs
+++ b/contracts/insurance_fund/src/storage.rs
@@ -1,11 +1,10 @@
 use crate::reserve::InsuranceFundReserve;
 use paste::paste;
 use soroban_sdk::token::TokenClient as SorobanTokenClient;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env, Vec};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, Symbol};
 use utils::bump::{bump_instance, bump_persistent};
 use utils::constant::THIRTEEN_DAY;
 use utils::errors::storage_errors::StorageError;
-use utils::state::token::DetailedToken;
 use utils::{
     generate_instance_storage_getter, generate_instance_storage_getter_and_setter,
     generate_instance_storage_getter_and_setter_with_default,
@@ -19,23 +18,20 @@ use utils::{
 enum DataKey {
     OracleRegistry, // the address of the Oracle Registry.
     PoolRouter,     // the address of the Pool Router.
-    PremiumToken,   // the address of the token used to pay premiums.
 
-    TokenWhitelist(Address),
-    DeletionQueue(Address),
+    PremiumToken,           // the address of the token used to pay premiums.
+    PremiumPayers(Address), // list of accounts allowed to pay premium.
 
-    Reserve(Address),
+    TokenWhitelist(Address), // map of token address to WhitelistTokenStatus.
+
+    Reserve(Address), // map of token address to InsuranceFundReserve.
 
     UnstakingPeriod, // a period of time stakers must wait once requesting withdrawal to actually withdraw.
-    OptimalInsurance, // the maximum amount of insurance (in Token amount) to adequately insure the protocol.
-    TotalShares,      // the total amount of issued shares.
-    SharesBase,       // exponent for lp shares (for rebasing).
+    OptimalInsurance, // the maximum amount of insurance to adequately insure the protocol.
     OptimalUtilization, // the optimal utilization point (utilization = current insurance / optimal insurance)
     BaseRate,           // the base interest rate when utilization is 0%
     RateSlopeA,         // the slope before hitting optimal utilization (gradual increase)
     RateSlopeB,         // the slope after optimal utilization (steep increase)
-
-    PremiumWhitelist(Address), // List of accounts explicitly allowed to pay premium
 
     // paused ops
     IsKilledDeposit,
@@ -44,31 +40,6 @@ enum DataKey {
 }
 
 // Addresses
-/// Checks if an address is whitelisted
-/// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
-pub fn get_token_whitelist_status(e: &Env, address: &Address) -> bool {
-    let key = DataKey::TokenWhitelist(address.clone());
-    match e.storage().persistent().get::<DataKey, DetailedToken>(&key) {
-        Some(_) => {
-            bump_persistent(e, &key);
-            true
-        }
-        None => false,
-    }
-}
-
-/// Sets whitelist status for an address
-/// If status is true, adds the address to whitelist; if false, removes it
-pub fn set_token_whitelist_status(e: &Env, token: &DetailedToken, status: bool) {
-    let key = DataKey::TokenWhitelist(token.address.clone());
-    if status {
-        e.storage().persistent().set(&key, token);
-        bump_persistent(e, &key);
-    } else {
-        e.storage().persistent().remove(&key);
-    }
-}
-
 generate_instance_storage_getter_and_setter_with_default!(
     oracle_registry,
     DataKey::OracleRegistry,
@@ -88,20 +59,7 @@ generate_instance_storage_getter_and_setter_with_default!(
     Address::from_str(&Env::default(), "")
 );
 
-// Config
-generate_instance_storage_getter_and_setter_with_default!(
-    whitelist_tokens,
-    DataKey::WhitelistToken,
-    Vec<Address>,
-    Vec::new(&Env::default())
-);
-generate_instance_storage_getter_and_setter_with_default!(
-    deletion_queue,
-    DataKey::DeletionQueue,
-    Vec<Address>,
-    Vec::new(&Env::default())
-);
-
+// Reserve
 pub(crate) fn get_reserve(e: &Env, token: &Address) -> InsuranceFundReserve {
     let key = DataKey::Reserve(token.clone());
     match e.storage().persistent().get(&key) {
@@ -119,6 +77,7 @@ pub(crate) fn put_reserve(e: &Env, token: &Address, reserve_info: &InsuranceFund
     bump_persistent(e, &key);
 }
 
+// Config
 generate_instance_storage_getter_and_setter_with_default!(
     unstaking_period,
     DataKey::UnstakingPeriod,
@@ -138,7 +97,7 @@ generate_instance_storage_getter_and_setter!(base_rate, DataKey::BaseRate, i32);
 generate_instance_storage_getter_and_setter!(rate_slope_a, DataKey::RateSlopeA, u32);
 generate_instance_storage_getter_and_setter!(rate_slope_b, DataKey::RateSlopeB, u32);
 
-// paused ops
+// Paused Ops
 generate_instance_storage_getter_and_setter_with_default!(
     is_killed_deposit,
     DataKey::IsKilledDeposit,
@@ -163,23 +122,12 @@ pub fn get_contract_token_balance(e: &Env, token: &Address) -> u128 {
     SorobanTokenClient::new(e, token).balance(&e.current_contract_address()) as u128
 }
 
-pub fn validate_whitelisted_token(e: &Env, token: &Address) {
-    let whitelisted_tokens = get_whitelist_tokens(&e);
-
-    if !whitelisted_tokens.contains(token) {
-        panic_with_error!(e, InsuranceFundError::UnsupportedToken)
-    }
-}
-
-// Whitelist functions
-// Note: These use manual implementation (not macros) because they are keyed storage patterns
-// that require persistent storage, custom TTL management, and Address-based keys.
-// This follows the same pattern as Component(Address) and ComponentBalance(Address) storage.
+// Premium Payers
 
 /// Checks if an address is whitelisted
 /// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
-pub fn get_premium_whitelist_status(e: &Env, address: &Address) -> bool {
-    let key = DataKey::PremiumWhitelist(address.clone());
+pub fn get_premium_payer_status(e: &Env, address: &Address) -> bool {
+    let key = DataKey::PremiumPayers(address.clone());
     match e.storage().persistent().get::<DataKey, Address>(&key) {
         Some(_) => {
             bump_persistent(e, &key);
@@ -191,12 +139,67 @@ pub fn get_premium_whitelist_status(e: &Env, address: &Address) -> bool {
 
 /// Sets whitelist status for an address
 /// If status is true, adds the address to whitelist; if false, removes it
-pub fn set_premium_whitelist_status(e: &Env, address: &Address, status: bool) {
-    let key = DataKey::PremiumWhitelist(address.clone());
+pub fn set_premium_payer_status(e: &Env, address: &Address, status: bool) {
+    let key = DataKey::PremiumPayers(address.clone());
     if status {
         e.storage().persistent().set(&key, address);
-        e.storage().persistent().extend_ttl(&key, 100000, 100000);
+        bump_persistent(e, &key);
     } else {
         e.storage().persistent().remove(&key);
     }
+}
+
+// Whitelist Token
+
+/// Checks if an address is whitelisted
+/// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
+pub fn get_token_whitelist_status(e: &Env, address: &Address) -> bool {
+    let key = DataKey::TokenWhitelist(address.clone());
+    match e
+        .storage()
+        .persistent()
+        .get::<DataKey, WhitelistToken>(&key)
+    {
+        Some(token) => {
+            bump_persistent(e, &key);
+            token.active
+        }
+        None => false,
+    }
+}
+
+pub fn get_token_whitelist(e: &Env, address: &Address) -> WhitelistToken {
+    let key = DataKey::TokenWhitelist(address.clone());
+    match e
+        .storage()
+        .persistent()
+        .get::<DataKey, WhitelistToken>(&key)
+    {
+        Some(token) => {
+            bump_persistent(e, &key);
+            token
+        }
+        None => panic_with_error!(e, StorageError::ValueNotInitialized),
+    }
+}
+
+/// Sets whitelist status for an address
+/// If status is true, adds the address to whitelist; if false, removes it
+pub fn set_token_whitelist(e: &Env, token: &WhitelistToken) {
+    let key = DataKey::TokenWhitelist(token.address.clone());
+    e.storage().persistent().set(&key, token);
+    bump_persistent(e, &key);
+}
+
+pub fn remove_token_whitelist(e: &Env, token: &Address) {
+    let key = DataKey::TokenWhitelist(token.clone());
+    e.storage().persistent().remove(&key);
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq, Eq)]
+pub struct WhitelistToken {
+    pub address: Address, // Address of the token
+    pub symbol: Symbol,   // Symbol of the token
+    pub active: bool,
 }

--- a/contracts/insurance_fund/src/storage.rs
+++ b/contracts/insurance_fund/src/storage.rs
@@ -1,17 +1,16 @@
+use crate::reserve::InsuranceFundReserve;
 use paste::paste;
 use soroban_sdk::token::TokenClient as SorobanTokenClient;
 use soroban_sdk::{contracttype, panic_with_error, Address, Env, Vec};
 use utils::bump::{bump_instance, bump_persistent};
 use utils::constant::THIRTEEN_DAY;
 use utils::errors::storage_errors::StorageError;
+use utils::state::token::DetailedToken;
 use utils::{
     generate_instance_storage_getter, generate_instance_storage_getter_and_setter,
     generate_instance_storage_getter_and_setter_with_default,
     generate_instance_storage_getter_with_default, generate_instance_storage_setter,
 };
-
-use crate::errors::InsuranceFundError;
-use crate::reserve::InsuranceFundReserve;
 
 // TODO: must we track the interest paid to avoid counting uncollected interest as insurance?
 
@@ -22,7 +21,7 @@ enum DataKey {
     PoolRouter,     // the address of the Pool Router.
     PremiumToken,   // the address of the token used to pay premiums.
 
-    WhitelistToken(Address),
+    TokenWhitelist(Address),
     DeletionQueue(Address),
 
     Reserve(Address),
@@ -45,6 +44,31 @@ enum DataKey {
 }
 
 // Addresses
+/// Checks if an address is whitelisted
+/// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
+pub fn get_token_whitelist_status(e: &Env, address: &Address) -> bool {
+    let key = DataKey::TokenWhitelist(address.clone());
+    match e.storage().persistent().get::<DataKey, DetailedToken>(&key) {
+        Some(_) => {
+            bump_persistent(e, &key);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Sets whitelist status for an address
+/// If status is true, adds the address to whitelist; if false, removes it
+pub fn set_token_whitelist_status(e: &Env, token: &DetailedToken, status: bool) {
+    let key = DataKey::TokenWhitelist(token.address.clone());
+    if status {
+        e.storage().persistent().set(&key, token);
+        bump_persistent(e, &key);
+    } else {
+        e.storage().persistent().remove(&key);
+    }
+}
+
 generate_instance_storage_getter_and_setter_with_default!(
     oracle_registry,
     DataKey::OracleRegistry,

--- a/contracts/insurance_fund/src/storage.rs
+++ b/contracts/insurance_fund/src/storage.rs
@@ -1,7 +1,7 @@
 use crate::reserve::InsuranceFundReserve;
 use paste::paste;
 use soroban_sdk::token::TokenClient as SorobanTokenClient;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env, Symbol};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, Symbol, Vec};
 use utils::bump::{bump_instance, bump_persistent};
 use utils::constant::THIRTEEN_DAY;
 use utils::errors::storage_errors::StorageError;
@@ -22,6 +22,7 @@ enum DataKey {
     PremiumToken,           // the address of the token used to pay premiums.
     PremiumPayers(Address), // list of accounts allowed to pay premium.
 
+    TokenWhitelistVec,
     TokenWhitelist(Address), // map of token address to WhitelistTokenStatus.
 
     Reserve(Address), // map of token address to InsuranceFundReserve.
@@ -149,7 +150,7 @@ pub fn set_premium_payer_status(e: &Env, address: &Address, status: bool) {
     }
 }
 
-// Whitelist Token
+// Token Whitelist
 
 /// Checks if an address is whitelisted
 /// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
@@ -194,6 +195,23 @@ pub fn set_token_whitelist(e: &Env, token: &WhitelistToken) {
 pub fn remove_token_whitelist(e: &Env, token: &Address) {
     let key = DataKey::TokenWhitelist(token.clone());
     e.storage().persistent().remove(&key);
+}
+
+pub fn get_token_whitelist_vec(e: &Env) -> Vec<Address> {
+    let key = DataKey::TokenWhitelistVec;
+    match e.storage().persistent().get(&key) {
+        Some(v) => {
+            bump_persistent(e, &key);
+            v
+        }
+        None => Vec::new(e),
+    }
+}
+
+pub fn set_token_whitelist_vec(e: &Env, pools: &Vec<Address>) {
+    let key = DataKey::TokenWhitelistVec;
+    e.storage().persistent().set(&key, pools);
+    bump_persistent(e, &key);
 }
 
 #[contracttype]

--- a/contracts/insurance_fund/src/storage.rs
+++ b/contracts/insurance_fund/src/storage.rs
@@ -1,6 +1,6 @@
 use paste::paste;
 use soroban_sdk::token::TokenClient as SorobanTokenClient;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, Vec};
 use utils::bump::{bump_instance, bump_persistent};
 use utils::constant::THIRTEEN_DAY;
 use utils::errors::storage_errors::StorageError;
@@ -10,14 +10,22 @@ use utils::{
     generate_instance_storage_getter_with_default, generate_instance_storage_setter,
 };
 
+use crate::errors::InsuranceFundError;
+use crate::reserve::InsuranceFundReserve;
+
 // TODO: must we track the interest paid to avoid counting uncollected interest as insurance?
 
 #[derive(Clone)]
 #[contracttype]
 enum DataKey {
-    OracleRegistry,
-    Token,      // the token address of supported deposits.
-    PoolRouter, // the address of the Pool Router.
+    OracleRegistry, // the address of the Oracle Registry.
+    PoolRouter,     // the address of the Pool Router.
+    PremiumToken,   // the address of the token used to pay premiums.
+
+    WhitelistToken(Address),
+    DeletionQueue(Address),
+
+    Reserve(Address),
 
     UnstakingPeriod, // a period of time stakers must wait once requesting withdrawal to actually withdraw.
     OptimalInsurance, // the maximum amount of insurance (in Token amount) to adequately insure the protocol.
@@ -44,19 +52,49 @@ generate_instance_storage_getter_and_setter_with_default!(
     Address::from_str(&Env::default(), "")
 );
 generate_instance_storage_getter_and_setter_with_default!(
-    token,
-    DataKey::Token,
-    Address,
-    Address::from_str(&Env::default(), "")
-);
-generate_instance_storage_getter_and_setter_with_default!(
     pool_router,
     DataKey::PoolRouter,
     Address,
     Address::from_str(&Env::default(), "")
 );
+generate_instance_storage_getter_and_setter_with_default!(
+    premium_token,
+    DataKey::PremiumToken,
+    Address,
+    Address::from_str(&Env::default(), "")
+);
 
 // Config
+generate_instance_storage_getter_and_setter_with_default!(
+    whitelist_tokens,
+    DataKey::WhitelistToken,
+    Vec<Address>,
+    Vec::new(&Env::default())
+);
+generate_instance_storage_getter_and_setter_with_default!(
+    deletion_queue,
+    DataKey::DeletionQueue,
+    Vec<Address>,
+    Vec::new(&Env::default())
+);
+
+pub(crate) fn get_reserve(e: &Env, token: &Address) -> InsuranceFundReserve {
+    let key = DataKey::Reserve(token.clone());
+    match e.storage().persistent().get(&key) {
+        Some(value) => {
+            bump_persistent(e, &key);
+            value
+        }
+        None => InsuranceFundReserve::new(token.clone(), e.ledger().timestamp()),
+    }
+}
+
+pub(crate) fn put_reserve(e: &Env, token: &Address, reserve_info: &InsuranceFundReserve) {
+    let key = DataKey::Reserve(token.clone());
+    e.storage().persistent().set(&key, reserve_info);
+    bump_persistent(e, &key);
+}
+
 generate_instance_storage_getter_and_setter_with_default!(
     unstaking_period,
     DataKey::UnstakingPeriod,
@@ -69,18 +107,8 @@ generate_instance_storage_getter_and_setter_with_default!(
     u128,
     0
 );
-generate_instance_storage_getter_and_setter_with_default!(
-    total_shares,
-    DataKey::TotalShares,
-    u128,
-    0
-);
-generate_instance_storage_getter_and_setter_with_default!(
-    shares_base,
-    DataKey::SharesBase,
-    u128,
-    0
-);
+
+// Interest
 generate_instance_storage_getter_and_setter!(optimal_utilization, DataKey::OptimalUtilization, u32);
 generate_instance_storage_getter_and_setter!(base_rate, DataKey::BaseRate, i32);
 generate_instance_storage_getter_and_setter!(rate_slope_a, DataKey::RateSlopeA, u32);
@@ -107,8 +135,16 @@ generate_instance_storage_getter_and_setter_with_default!(
 );
 
 // Utils
-pub fn get_insurance_vault_amount(e: &Env) -> u128 {
-    SorobanTokenClient::new(e, &get_token(e)).balance(&e.current_contract_address()) as u128
+pub fn get_insurance_vault_amount(e: &Env, token: &Address) -> u128 {
+    SorobanTokenClient::new(e, token).balance(&e.current_contract_address()) as u128
+}
+
+pub fn validate_whitelisted_token(e: &Env, token: &Address) {
+    let whitelisted_tokens = get_whitelist_tokens(&e);
+
+    if !whitelisted_tokens.contains(token) {
+        panic_with_error!(e, InsuranceFundError::UnsupportedToken)
+    }
 }
 
 // Whitelist functions

--- a/contracts/insurance_fund/src/storage.rs
+++ b/contracts/insurance_fund/src/storage.rs
@@ -135,7 +135,7 @@ generate_instance_storage_getter_and_setter_with_default!(
 );
 
 // Utils
-pub fn get_insurance_vault_amount(e: &Env, token: &Address) -> u128 {
+pub fn get_contract_token_balance(e: &Env, token: &Address) -> u128 {
     SorobanTokenClient::new(e, token).balance(&e.current_contract_address()) as u128
 }
 

--- a/modules/utils/src/state/token.rs
+++ b/modules/utils/src/state/token.rs
@@ -17,10 +17,3 @@ pub struct AddressAndAmount {
     // The total amount of those tokens in the pool
     pub amount: u128,
 }
-
-#[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DetailedToken {
-    pub address: Address, // Address of the token
-    pub symbol: Symbol,  // Symbol of the token
-}

--- a/modules/utils/src/state/token.rs
+++ b/modules/utils/src/state/token.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, BytesN, String};
+use soroban_sdk::{contracttype, Address, BytesN, String, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -16,4 +16,11 @@ pub struct AddressAndAmount {
     pub address: Address,
     // The total amount of those tokens in the pool
     pub amount: u128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetailedToken {
+    pub address: Address, // Address of the token
+    pub symbol: Symbol,  // Symbol of the token
 }

--- a/scripts/admin/insurance/whitelist_token.sh
+++ b/scripts/admin/insurance/whitelist_token.sh
@@ -1,0 +1,86 @@
+# Ensure the script exits on any errors
+set -e
+
+# Check if the arguments are provided
+# Required: identity_string, network, pool_address, fund_type, fund_address
+if [ "$#" -lt 4 ]; then
+    echo "Usage: $0 <identity_string> <network> <pool_address> <fund_type> <fund_address>"
+    exit 1
+fi
+
+IDENTITY_STRING=$1
+NETWORK=$2
+POOL_ROUTER_ADDR=$3
+FUND_TYPE=""
+FUND_ADDR=$4
+
+# Load env vars dynamically
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/load-env.sh" "$NETWORK"
+
+# Parse input flags
+while [[ "$#" -gt 0 ]]; do
+    case "$3" in
+    -b)
+        FUND_TYPE="buffer"
+        ;;
+    -if)
+        FUND_TYPE="insurance_fund"
+        ;;
+    *)
+        echo "Unknown option: $1"
+        echo "Usage: $0 [-b | -if]"
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Validate selection
+if [ -z "$FUND_TYPE" ]; then
+    echo "Error: You must specify either -b (buffer) or -if (insurance fund)"
+    exit 1
+fi
+
+echo "Selected fund: $FUND_TYPE"
+
+if [ -z "$FUND_ADDR" ]; then
+    echo "Error: You must specify either -b (buffer) or -if (insurance fund)"
+    exit 1
+fi
+
+if [ "$FUND_TYPE" = "buffer" ]; then
+    echo "Running logic for buffer..."
+
+    stellar contract invoke \
+        --id $FUND_ADDR \
+        --source $IDENTITY_STRING \
+        --network $NETWORK \
+        --rpc-url $STELLAR_RPC_URL \
+        --network-passphrase "$STELLAR_NETWORK_PASSPHRASE" \
+        --fee $STELLAR_BASE_FEE \
+        -- \
+        resolve_liquidity_deficit \
+        --admin $ADMIN_ADDRESS \
+        --token $XLM \
+        --amount 0 \
+        --pool_address $POOL_ADDR
+
+elif [ "$FUND_TYPE" = "insurance_fund" ]; then
+    echo "Running logic for insurance fund..."
+
+    stellar contract invoke \
+        --id $FUND_ADDR \
+        --source $IDENTITY_STRING \
+        --network $NETWORK \
+        --rpc-url $STELLAR_RPC_URL \
+        --network-passphrase "$STELLAR_NETWORK_PASSPHRASE" \
+        --fee $STELLAR_BASE_FEE \
+        -- \
+        resolve_liquidity_deficit \
+        --admin $ADMIN_ADDRESS \
+        --pool_address $POOL_ADDR
+
+fi
+
+echo "Liquidity resolution initiated."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -194,8 +194,10 @@ stellar contract invoke \
     initialize \
     --admin $ADMIN_ADDRESS \
     --emergency_admin $ADMIN_ADDRESS \
-    --token $XLM_ADDRESS \
+    --oracle_registry $ORACLE_REGISTRY_ADDR \
     --pool_router $POOL_ROUTER_ADDR \
+    --premium_token $XLM_ADDRESS \
+    --whitelist_tokens "[\"$XLM_ADDRESS\"]" \
     --unstaking_period $THIRTEEN_DAYS \
     --optimal_utilization 8000 \
     --base_rate 200 \


### PR DESCRIPTION
This PR does the following:
- Adds an InsuranceFundReserve type to support tracking multiple tokens for coverage
- Adds whitelisted tokens list
- Adds a sync and skim function
- Adds a PremiumToken value 