### PR TITLE
fix: Double Pool Fee

### DIFF
--- a/contracts/liquidity_calculator/Cargo.toml
+++ b/contracts/liquidity_calculator/Cargo.toml
@@ -13,6 +13,7 @@ access_control = { workspace = true }
 soroban-sdk = { workspace = true }
 soroban-fixed-point-math = { workspace = true }
 upgrade = { workspace = true }
+utils = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/liquidity_calculator/src/constants.rs
+++ b/contracts/liquidity_calculator/src/constants.rs
@@ -1,5 +1,3 @@
-pub(crate) const FEE_MULTIPLIER: u128 = 10_000;
-
 // `PRECISION` is a constant that is used to maintain the precision of calculations.
 // It's a factor by which values are multiplied or divided to maintain precision during arithmetic operations.
 // This is particularly useful when dealing with fractional values in integer calculations,

--- a/contracts/liquidity_calculator/src/standard_pool.rs
+++ b/contracts/liquidity_calculator/src/standard_pool.rs
@@ -1,6 +1,6 @@
-use crate::constants::FEE_MULTIPLIER;
 use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::{Env, Vec};
+use utils::constant::FEE_MULTIPLIER;
 
 // Derivation of the closed-form result for the integral:
 //

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -9,8 +9,8 @@ use crate::interface::{
 use crate::plane::update_plane;
 use crate::plane_interface::Plane;
 use crate::pool::{
-    get_amount_out_strict_receive, get_delta_a, get_net_liquidity_imbalance, get_oracle_price,
-    peg_price, rebalance, update_volume_30d, validate_oracle_price_with_pool,
+    get_amount_out, get_amount_out_strict_receive, get_delta_a, get_net_liquidity_imbalance,
+    get_oracle_price, rebalance, update_volume_30d, validate_oracle_price_with_pool,
 };
 use crate::storage::{
     get_insurance_fund_from_router, get_is_killed_claim, get_is_killed_deposit, get_is_killed_swap,
@@ -484,7 +484,7 @@ impl PoolTrait for Pool {
             panic_with_error!(&e, PoolValidationError::EmptyPool);
         }
 
-        let (out, fee) = pool.get_amount_out(&e, in_amount, reserve_sell, reserve_buy);
+        let out = get_amount_out(in_amount, reserve_sell, reserve_buy);
 
         if out < out_min {
             panic_with_error!(&e, PoolValidationError::OutMinNotSatisfied);
@@ -597,9 +597,7 @@ impl PoolTrait for Pool {
         let reserve_buy = reserves.get(out_idx).unwrap();
 
         let pool = get_pool(&e);
-        let out = pool
-            .get_amount_out(&e, in_amount, reserve_sell, reserve_buy)
-            .0;
+        let out = get_amount_out(in_amount, reserve_sell, reserve_buy);
 
         let base_oracle_price_data = get_oracle_price(&e, &pool.base_asset, NormalAction::Swap);
         let quote_oracle_price_data = get_oracle_price(&e, &pool.quote_asset, NormalAction::Swap);
@@ -683,13 +681,7 @@ impl PoolTrait for Pool {
             panic_with_error!(&e, PoolValidationError::EmptyPool);
         }
 
-        let (in_amount, fee) = get_amount_out_strict_receive(
-            &e,
-            out_amount,
-            reserve_sell,
-            reserve_buy,
-            pool.fee_fraction,
-        );
+        let in_amount = get_amount_out_strict_receive(out_amount, reserve_sell, reserve_buy);
 
         if in_amount > in_max {
             panic_with_error!(&e, PoolValidationError::InMaxNotSatisfied);
@@ -814,14 +806,7 @@ impl PoolTrait for Pool {
         let reserve_buy = reserves.get(out_idx).unwrap();
 
         let pool = get_pool(&e);
-        let out = get_amount_out_strict_receive(
-            &e,
-            out_amount,
-            reserve_sell,
-            reserve_buy,
-            pool.fee_fraction,
-        )
-        .0;
+        let out = get_amount_out_strict_receive(out_amount, reserve_sell, reserve_buy);
 
         let base_oracle_price_data = get_oracle_price(&e, &pool.base_asset, NormalAction::Swap);
         let quote_oracle_price_data = get_oracle_price(&e, &pool.quote_asset, NormalAction::Swap);

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -18,10 +18,10 @@ use soroban_sdk::Symbol;
 use soroban_sdk::Vec;
 use soroban_sdk::{panic_with_error, Env};
 
+use utils::constant::PRICE_PRECISION;
 use utils::constant::PRICE_PRECISION_I64;
 use utils::constant::PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128;
 use utils::constant::TWENTY_FOUR_HOUR;
-use utils::constant::{FEE_MULTIPLIER, PRICE_PRECISION};
 use utils::math::safe_math::SafeMath;
 use utils::math::stats::calculate_rolling_sum;
 use utils::state::oracle_registry::HistoricalOracleData;
@@ -377,49 +377,116 @@ pub fn rebalance(e: &Env, base_oracle_price: u128, quote_oracle_price: u128, red
     }
 }
 
-// Calculates the input amount required to receive a fixed output amount in a swap,
-// factoring in the trading fee.
-//
-// This is used in strict-receive swaps where the output is guaranteed and the input
-// is determined. If the total value with fee exceeds the reserve, the function panics.
-//
-// # Arguments
-// * `e` - Soroban environment reference.
-// * `out_amount` - Desired amount of output token to receive.
-// * `reserve_sell` - Reserve of the token being sold.
-// * `reserve_buy` - Reserve of the token being bought.
-// * `fee_fraction` - Trading fee as a fraction (e.g., 30 = 0.3%).
-//
-// # Returns
-// * `(u128, u128)` — Tuple:
-//   - Input amount required to receive `out_amount`
-//   - Fee charged as the difference between input and output value.
-//
-// # Panics
-// - If the fee-adjusted input exceeds available reserves.
+/// Calculates the output amount of tokens for a swap given input and pool reserves.
+///
+/// This function implements a constant product AMM–style formula with fees applied externally (using PoolSwapFee).
+/// The calculation follows:
+///
+/// ```text
+/// out = in * reserve_buy / (reserve_sell + in) - fee
+/// ```
+///
+/// The `fee` portion is not handled inside this function—it must be deducted by the caller
+/// after receiving the raw output value.
+///
+/// # Arguments
+///
+/// * `in_amount` – The amount of input tokens being sold into the pool.
+/// * `reserve_sell` – The current reserve of the token being sold (the pool’s supply of the input token).
+/// * `reserve_buy` – The current reserve of the token being bought (the pool’s supply of the output token).
+///
+/// # Returns
+///
+/// A u128 `amount_out`:
+/// * `amount_out` – The number of output tokens the user would receive before fee deduction.
+///
+/// Returns `0` if `in_amount == 0`.
+///
+/// # Examples
+///
+/// ```rust
+/// // Example reserves
+/// let reserve_sell: u128 = 1_000_000;
+/// let reserve_buy: u128 = 500_000;
+/// let in_amount: u128 = 10_000;
+///
+/// // Calculate output before fee
+/// let out = contract.get_amount_out(in_amount, reserve_sell, reserve_buy);
+///
+/// assert!(out > 0);
+/// ```
+pub fn get_amount_out(in_amount: u128, reserve_sell: u128, reserve_buy: u128) -> u128 {
+    if in_amount == 0 {
+        return 0;
+    }
+
+    // +1 just in case there were some rounding errors & convert to real units in place
+    let result = in_amount
+        .fixed_mul_floor(reserve_buy, reserve_sell.saturating_add(in_amount))
+        .unwrap()
+        + 1;
+
+    result
+}
+
+/// Calculates the required input amount for a **strict receive** swap given
+/// a desired output amount and current pool reserves.
+///
+/// This function computes how much of the *sell token* must be provided in
+/// order to guarantee receiving exactly `out_amount` of the *buy token*,
+/// assuming a constant product AMM invariant.  
+///
+/// The calculation uses a floor division (`fixed_mul_floor`) and then adds
+/// `+1` to the result to guard against rounding errors, ensuring the pool
+/// always receives enough input tokens to cover the desired output.
+///
+/// # Arguments
+///
+/// * `out_amount` – The amount of output tokens the trader wishes to receive.  
+/// * `reserve_sell` – The current reserve of the token being sold
+///   (the pool’s input-side liquidity).  
+/// * `reserve_buy` – The current reserve of the token being bought
+///   (the pool’s output-side liquidity).  
+///
+/// # Returns
+///
+/// * `u128` – The minimum required input amount of the sell token
+///   needed to guarantee the `out_amount` is fulfilled.  
+///   Returns `0` if `out_amount == 0`.  
+///
+/// # Notes
+///
+/// * The extra `+1` ensures rounding errors never result in underpayment.  
+/// * The function does **not** apply protocol or trading fees — callers
+///   must account for those separately if required.  
+///
+/// # Examples
+///
+/// ```rust
+/// let reserve_sell: u128 = 1_000_000;
+/// let reserve_buy: u128 = 500_000;
+/// let desired_out: u128 = 10_000;
+///
+/// // Compute required input for a strict receive
+/// let required_in = contract::get_amount_out_strict_receive(desired_out, reserve_sell, reserve_buy);
+///
+/// assert!(required_in > 0);
+/// ```
 pub fn get_amount_out_strict_receive(
-    e: &Env,
     out_amount: u128,
     reserve_sell: u128,
     reserve_buy: u128,
-    fee_fraction: u32,
-) -> (u128, u128) {
+) -> u128 {
     if out_amount == 0 {
-        return (0, 0);
+        return 0;
     }
 
-    let dy_w_fee = out_amount
-        .fixed_mul_ceil(FEE_MULTIPLIER, (FEE_MULTIPLIER - (fee_fraction as u128)))
-        .unwrap();
-    // if total value including fee is more than the reserve, math can't be done properly
-    if dy_w_fee >= reserve_buy {
-        panic_with_error!(e, PoolValidationError::InsufficientBalance);
-    }
     // +1 just in case there were some rounding errors & convert to real units in place
     let result = reserve_buy
-        .fixed_mul_floor(reserve_sell, (reserve_buy - dy_w_fee))
+        .fixed_mul_floor(reserve_sell, reserve_buy)
         .unwrap()
         - reserve_sell
         + 1;
-    (result, dy_w_fee - out_amount)
+
+    result
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -1,7 +1,6 @@
 use core::cmp::max;
 
 use crate::errors::PoolError;
-use crate::errors::PoolValidationError;
 use crate::events::Events as LiquidityPoolEvents;
 use crate::events::PoolEvents;
 use crate::storage::get_last_trade_ts;

--- a/contracts/pool_swap_fee/src/contract.rs
+++ b/contracts/pool_swap_fee/src/contract.rs
@@ -30,7 +30,8 @@ use token_lp::{get_total_lp_tokens, get_user_balance_lp};
 use upgrade::events::Events as UpgradeEvents;
 use upgrade::interface::UpgradeableContract;
 use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
-use utils::constant::{FEE_DENOMINATOR, PRICE_PRECISION, THIRTY_DAY};
+use utils::constant::{PRICE_PRECISION, THIRTY_DAY};
+use utils::math::pool::calculate_fee;
 use utils::math::safe_math::SafeMath;
 use utils::math::stats::calculate_rolling_sum;
 use utils::state::pool::{PoolInfo, SwapDirection};
@@ -142,9 +143,8 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
         // Update fee if on token_in
         if direction == SwapDirection::Buy {
             quote_asset_amount = in_amount;
-            fee_amount = (in_amount * (pool_info.pool_response.pool.fee_fraction as u128))
-                / (FEE_DENOMINATOR as u128);
-            in_amount_mut = in_amount - fee_amount;
+            fee_amount = calculate_fee(in_amount, pool_info.pool_response.pool.fee_fraction);
+            in_amount_mut = in_amount.saturating_sub(fee_amount);
         }
 
         e.authorize_as_current_contract(vec![
@@ -181,11 +181,11 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
         // Update fee if on token_out
         if direction == SwapDirection::Sell {
             quote_asset_amount = amount_out;
-            fee_amount = (amount_out * (pool_info.pool_response.pool.fee_fraction as u128))
-                / (FEE_DENOMINATOR as u128);
+            fee_amount = calculate_fee(amount_out, pool_info.pool_response.pool.fee_fraction);
         }
 
-        amount_out_w_fee = amount_out - fee_amount;
+        amount_out_w_fee = amount_out.saturating_sub(fee_amount);
+
         if amount_out_w_fee < out_min {
             panic_with_error!(&e, PoolSwapFeeError::OutMinNotSatisfied);
         }
@@ -208,8 +208,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
 
         // LP FEES
         let lp_revenue_fraction = get_lp_revenue_fraction(&e);
-        let lp_fee_amount =
-            (fee_amount * (lp_revenue_fraction as u128)) / (FEE_DENOMINATOR as u128);
+        let lp_fee_amount = calculate_fee(fee_amount, lp_revenue_fraction);
 
         // Add bounds checking to prevent fee calculation underflow when LP fees exceed total fees
         validate!(
@@ -238,7 +237,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             ),
         );
 
-        let mut if_premium_paid: u128 = 0;
+        let mut insurance_premium_paid: u128 = 0;
 
         if insurance_premium_rate > 0 {
             let estimated_annual_volume = updated_volume_30d.fixed_mul_floor(365, 30).unwrap();
@@ -258,7 +257,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             if insurance_premium_to_pay > 0 {
                 // TODO: must we also call the Pool to update last_revenue_withdraw_ts and rev_withdraw_since_last_settle?
 
-                if_premium_paid = e.invoke_contract(
+                insurance_premium_paid = e.invoke_contract(
                     &insurance_fund,
                     &Symbol::new(&e, "pay_premium"),
                     Vec::from_array(
@@ -283,7 +282,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             amount_out,
             fee_amount,
             lp_fee_amount,
-            if_premium_paid,
+            insurance_premium_paid,
             protocol_fee_amount,
         );
 

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -59,9 +59,6 @@ pub const MIN_LIQUIDITY: u128 = 1_000;
 // Pool Router
 pub const MAX_POOL_FEE: u32 = 100; // 1%
 
-// Swap Fee
-pub const FEE_DENOMINATOR: u32 = 10000;
-
 // Incentives
 pub const REWARD_PRECISION: u128 = 1_000_000_000_000_000_0000000;
 

--- a/modules/utils/src/math/pool.rs
+++ b/modules/utils/src/math/pool.rs
@@ -53,3 +53,47 @@ pub fn sanitize_new_price(
 
     capped_update_price
 }
+
+/// Computes a fee using ceiling rounding in fixed-point arithmetic.
+///
+/// The fee is calculated as:
+///
+/// ```text
+/// fee = ceil(amount * fee_fraction / FEE_MULTIPLIER)
+/// ```
+///
+/// where `fee_fraction` and `FEE_MULTIPLIER` share the same scale
+/// (e.g., `fee_fraction = 30` and `FEE_MULTIPLIER = 10_000` for 30 bps).
+/// Ceiling rounding ensures the protocol never under-collects due to truncation.
+///
+/// # Arguments
+///
+/// * `amount` — The gross amount to which the fee applies.
+/// * `fee_fraction` — The fee numerator in the same scale as `FEE_MULTIPLIER` (e.g., bps).
+///
+/// # Returns
+///
+/// * `u128` — The fee, rounded up (ceiling).
+///   Returns `0` if an overflow occurs inside `fixed_mul_ceil` (current behavior).
+///
+/// # Notes
+///
+/// * This uses `fixed_mul_ceil` and propagates its overflow handling by returning `0`
+///   on `None` via `unwrap_or(0)`. Consider replacing with explicit error handling
+///   if you need to distinguish overflow from a legitimate zero fee.
+///
+/// # Examples
+///
+/// ```rust
+/// // 30 bps on 1_000_000 with ceiling rounding
+/// // fee = ceil(1_000_000 * 30 / 10_000) = ceil(3_000 / 10) = 300
+/// let fee = calculate_fee(1_000_000, 30);
+/// assert_eq!(fee, 300);
+/// ```
+pub fn calculate_fee(amount: u128, fee_fraction: u32) -> u128 {
+    let result = amount
+        .fixed_mul_ceil(fee_fraction as u128, FEE_MULTIPLIER)
+        .unwrap_or(0);
+
+    result
+}

--- a/modules/utils/src/math/pool.rs
+++ b/modules/utils/src/math/pool.rs
@@ -1,9 +1,67 @@
+use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::Env;
 
-use crate::constant::DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR;
+use crate::constant::{DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR, FEE_MULTIPLIER};
 
 use super::safe_math::SafeMath;
 
+/// Sanitizes a new oracle price update by clamping it within a band around the TWAP.
+///
+/// This function guards against abrupt oracle spikes by limiting `new_price` to
+/// a maximum delta from `last_price_twap`. If `sanitize_clamp_denominator` is
+/// non-zero, the allowed price band is:
+///
+/// ```text
+/// band = last_price_twap / sanitize_clamp_denominator
+/// ```
+///
+/// The sanitized price is then:
+///
+/// ```text
+/// if abs(new_price - last_price_twap) > band:
+///     // clamp toward the TWAP edge
+///     capped = last_price_twap ± band
+/// else:
+///     capped = new_price
+/// ```
+///
+/// If `sanitize_clamp_denominator == 0`, no clamping is applied and `new_price` is returned.
+/// If `last_price_twap == 0`, normalization isn’t attempted and `new_price` is returned as-is.
+///
+/// # Arguments
+///
+/// * `e` — Soroban [`Env`] for safe math helpers (e.g., `safe_add`, `safe_sub`, `safe_div`).
+/// * `new_price` — The latest oracle price reading (u128, must be > 0).
+/// * `last_price_twap` — The previous time-weighted average price used as an anchor (u128).
+/// * `sanitize_clamp_denominator` — Denominator controlling the allowed deviation.
+///   - If 0, disables clamping.
+///   - If non-zero, the max deviation is `last_price_twap / sanitize_clamp_denominator`.
+///   - If omitted/0, a default (`DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR`) is used.
+///
+/// # Returns
+///
+/// * `u128` — The sanitized price, clamped to the TWAP band if applicable.
+///
+/// # Panics
+///
+/// * Panics if `new_price == 0`.
+/// * Asserts that `last_price_twap` is non-negative (redundant for `u128`, but retained for clarity).
+///
+/// # Notes
+///
+/// * Uses `safe_*` helpers to avoid overflow/underflow on intermediate arithmetic.
+/// * When clamping downward, if `band >= last_price_twap`, the function returns `0`
+///   to avoid underflow and represent a floor at zero.
+///
+/// # Examples
+///
+/// ```rust
+/// // Allow at most ±1% move from TWAP (denominator 100)
+/// let twap = 100_000u128;
+/// let new = 105_000u128; // +5%
+/// let clamped = sanitize_new_price(&env, new, twap, 100);
+/// assert_eq!(clamped, 101_000); // TWAP + 1% band
+/// ```
 pub fn sanitize_new_price(
     e: &Env,
     new_price: u128,
@@ -12,6 +70,7 @@ pub fn sanitize_new_price(
 ) -> u128 {
     assert!(new_price > 0, "new_price must be positive");
     assert!(last_price_twap >= 0, "last_price_twap must be non-negative");
+
     // when/if twap is 0, dont try to normalize new_price
     if last_price_twap == 0 {
         return new_price;

--- a/modules/utils/src/state/pool.rs
+++ b/modules/utils/src/state/pool.rs
@@ -1,10 +1,7 @@
-use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::contracttype;
 use soroban_sdk::Address;
-use soroban_sdk::Env;
 use soroban_sdk::Symbol;
 
-use crate::constant::FEE_MULTIPLIER;
 use crate::state::access::PrivilegedAddresses;
 use crate::state::token::AddressAndAmount;
 use crate::state::token::TokenInitInfo;

--- a/modules/utils/src/state/pool.rs
+++ b/modules/utils/src/state/pool.rs
@@ -61,23 +61,6 @@ impl Pool {
             PoolTier::Isolated => 10_u64,
         }
     }
-
-    pub fn get_amount_out(
-        &self,
-        e: &Env,
-        in_amount: u128,
-        reserve_sell: u128,
-        reserve_buy: u128,
-    ) -> (u128, u128) {
-        if in_amount == 0 {
-            return (0, 0);
-        }
-
-        // in * reserve_buy / (reserve_sell + in) - fee
-        let result = in_amount.fixed_mul_floor(&e, &reserve_buy, &(reserve_sell + in_amount));
-        let fee = result.fixed_mul_ceil(&e, &(self.fee_fraction as u128), &FEE_MULTIPLIER);
-        (result - fee, fee)
-    }
 }
 
 #[contracttype]


### PR DESCRIPTION
The `pool.fee_fraction` was being applied by default to all swaps, creating a double fee collection when swaps are initiated by the `PoolSwapFee` contract.