### PR TITLE
feat: Add `delta_a` to liquidity and swap events on Pool and PoolRouter

### DIFF
--- a/bindings/insurance_fund/src/index.ts
+++ b/bindings/insurance_fund/src/index.ts
@@ -884,6 +884,26 @@ export interface Client {
   }) => Promise<AssembledTransaction<null>>
 
   /**
+   * Construct and simulate a set_optimal_insurance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  set_optimal_insurance: ({admin, optimal_insurance}: {admin: string, optimal_insurance: u128}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<null>>
+
+  /**
    * Construct and simulate a add_token_whitelist transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
   add_token_whitelist: ({admin, token}: {admin: string, token: WhitelistToken}, options?: {
@@ -1370,6 +1390,7 @@ export class Client extends ContractClient {
         "AAAAAAAAAAAAAAAYc2V0X3ByZW1pdW1fcGF5ZXJfc3RhdHVzAAAAAwAAAAAAAAAFYWRtaW4AAAAAAAATAAAAAAAAAAVwYXllcgAAAAAAABMAAAAAAAAABnN0YXR1cwAAAAAAAQAAAAA=",
         "AAAAAAAAAAAAAAAUc2V0X3Vuc3Rha2luZ19wZXJpb2QAAAACAAAAAAAAAAVhZG1pbgAAAAAAABMAAAAAAAAAEHVuc3Rha2luZ19wZXJpb2QAAAAGAAAAAA==",
         "AAAAAAAAAAAAAAAPc2V0X3JhdGVfY29uZmlnAAAAAAUAAAAAAAAABWFkbWluAAAAAAAAEwAAAAAAAAATb3B0aW1hbF91dGlsaXphdGlvbgAAAAAEAAAAAAAAAAliYXNlX3JhdGUAAAAAAAAFAAAAAAAAAAxyYXRlX3Nsb3BlX2EAAAAEAAAAAAAAAAxyYXRlX3Nsb3BlX2IAAAAEAAAAAA==",
+        "AAAAAAAAAAAAAAAVc2V0X29wdGltYWxfaW5zdXJhbmNlAAAAAAAAAgAAAAAAAAAFYWRtaW4AAAAAAAATAAAAAAAAABFvcHRpbWFsX2luc3VyYW5jZQAAAAAAAAoAAAAA",
         "AAAAAAAAAAAAAAATYWRkX3Rva2VuX3doaXRlbGlzdAAAAAACAAAAAAAAAAVhZG1pbgAAAAAAABMAAAAAAAAABXRva2VuAAAAAAAH0AAAAA5XaGl0ZWxpc3RUb2tlbgAAAAAAAA==",
         "AAAAAAAAAAAAAAAac2V0X3Rva2VuX3doaXRlbGlzdF9zdGF0dXMAAAAAAAMAAAAAAAAABWFkbWluAAAAAAAAEwAAAAAAAAAFdG9rZW4AAAAAAAATAAAAAAAAAAZzdGF0dXMAAAAAAAEAAAAA",
         "AAAAAAAAAAAAAAAWcmVtb3ZlX3doaXRlbGlzdF90b2tlbgAAAAAAAgAAAAAAAAAFYWRtaW4AAAAAAAATAAAAAAAAAAV0b2tlbgAAAAAAABMAAAAA",
@@ -1459,6 +1480,7 @@ export class Client extends ContractClient {
         set_premium_payer_status: this.txFromJSON<null>,
         set_unstaking_period: this.txFromJSON<null>,
         set_rate_config: this.txFromJSON<null>,
+        set_optimal_insurance: this.txFromJSON<null>,
         add_token_whitelist: this.txFromJSON<null>,
         set_token_whitelist_status: this.txFromJSON<null>,
         remove_whitelist_token: this.txFromJSON<null>,

--- a/bindings/pool/src/index.ts
+++ b/bindings/pool/src/index.ts
@@ -370,7 +370,7 @@ export interface Client {
      * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
      */
     simulate?: boolean;
-  }) => Promise<AssembledTransaction<readonly [u128, u128]>>
+  }) => Promise<AssembledTransaction<readonly [u128, u128, i128]>>
 
   /**
    * Construct and simulate a swap transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -390,7 +390,7 @@ export interface Client {
      * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
      */
     simulate?: boolean;
-  }) => Promise<AssembledTransaction<u128>>
+  }) => Promise<AssembledTransaction<readonly [u128, i128, i128]>>
 
   /**
    * Construct and simulate a estimate_swap transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -430,7 +430,7 @@ export interface Client {
      * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
      */
     simulate?: boolean;
-  }) => Promise<AssembledTransaction<u128>>
+  }) => Promise<AssembledTransaction<readonly [u128, i128, i128]>>
 
   /**
    * Construct and simulate a estimate_swap_strict_receive transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -470,7 +470,7 @@ export interface Client {
      * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
      */
     simulate?: boolean;
-  }) => Promise<AssembledTransaction<u128>>
+  }) => Promise<AssembledTransaction<readonly [u128, i128]>>
 
   /**
    * Construct and simulate a share_id transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -1672,12 +1672,12 @@ export class Client extends ContractClient {
     super(
       new ContractSpec([ "AAAAAAAAAAAAAAAOaW5pdGlhbGl6ZV9hbGwAAAAAAAEAAAAAAAAABnBhcmFtcwAAAAAH0AAAABNJbml0aWFsaXplQWxsUGFyYW1zAAAAAAA=",
         "AAAAAAAAAAAAAAAKaW5pdGlhbGl6ZQAAAAAAAQAAAAAAAAAGcGFyYW1zAAAAAAfQAAAAEEluaXRpYWxpemVQYXJhbXMAAAAA",
-        "AAAAAAAAAAAAAAAHZGVwb3NpdAAAAAACAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAOdG9rZW5fYl9hbW91bnQAAAAAAAoAAAABAAAD7QAAAAIAAAAKAAAACg==",
-        "AAAAAAAAAAAAAAAEc3dhcAAAAAQAAAAAAAAABHVzZXIAAAATAAAAAAAAAAlkaXJlY3Rpb24AAAAAAAfQAAAADVN3YXBEaXJlY3Rpb24AAAAAAAAAAAAACWluX2Ftb3VudAAAAAAAAAoAAAAAAAAAB291dF9taW4AAAAACgAAAAEAAAAK",
+        "AAAAAAAAAAAAAAAHZGVwb3NpdAAAAAACAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAOdG9rZW5fYl9hbW91bnQAAAAAAAoAAAABAAAD7QAAAAMAAAAKAAAACgAAAAs=",
+        "AAAAAAAAAAAAAAAEc3dhcAAAAAQAAAAAAAAABHVzZXIAAAATAAAAAAAAAAlkaXJlY3Rpb24AAAAAAAfQAAAADVN3YXBEaXJlY3Rpb24AAAAAAAAAAAAACWluX2Ftb3VudAAAAAAAAAoAAAAAAAAAB291dF9taW4AAAAACgAAAAEAAAPtAAAAAwAAAAoAAAALAAAACw==",
         "AAAAAAAAAAAAAAANZXN0aW1hdGVfc3dhcAAAAAAAAAIAAAAAAAAACWRpcmVjdGlvbgAAAAAAB9AAAAANU3dhcERpcmVjdGlvbgAAAAAAAAAAAAAJaW5fYW1vdW50AAAAAAAACgAAAAEAAAPtAAAAAgAAAAoAAAAL",
-        "AAAAAAAAAAAAAAATc3dhcF9zdHJpY3RfcmVjZWl2ZQAAAAAEAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAJZGlyZWN0aW9uAAAAAAAH0AAAAA1Td2FwRGlyZWN0aW9uAAAAAAAAAAAAAApvdXRfYW1vdW50AAAAAAAKAAAAAAAAAAZpbl9tYXgAAAAAAAoAAAABAAAACg==",
+        "AAAAAAAAAAAAAAATc3dhcF9zdHJpY3RfcmVjZWl2ZQAAAAAEAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAJZGlyZWN0aW9uAAAAAAAH0AAAAA1Td2FwRGlyZWN0aW9uAAAAAAAAAAAAAApvdXRfYW1vdW50AAAAAAAKAAAAAAAAAAZpbl9tYXgAAAAAAAoAAAABAAAD7QAAAAMAAAAKAAAACwAAAAs=",
         "AAAAAAAAAAAAAAAcZXN0aW1hdGVfc3dhcF9zdHJpY3RfcmVjZWl2ZQAAAAIAAAAAAAAACWRpcmVjdGlvbgAAAAAAB9AAAAANU3dhcERpcmVjdGlvbgAAAAAAAAAAAAAKb3V0X2Ftb3VudAAAAAAACgAAAAEAAAPtAAAAAgAAAAoAAAAL",
-        "AAAAAAAAAAAAAAAId2l0aGRyYXcAAAACAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAMc2hhcmVfYW1vdW50AAAACgAAAAEAAAAK",
+        "AAAAAAAAAAAAAAAId2l0aGRyYXcAAAACAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAMc2hhcmVfYW1vdW50AAAACgAAAAEAAAPtAAAAAgAAAAoAAAAL",
         "AAAAAAAAAAAAAAAIc2hhcmVfaWQAAAAAAAAAAQAAABM=",
         "AAAAAAAAAAAAAAAQZ2V0X3RvdGFsX3NoYXJlcwAAAAAAAAABAAAACg==",
         "AAAAAAAAAAAAAAAKZ2V0X3Rva2VucwAAAAAAAAAAAAEAAAPqAAAAEw==",
@@ -1778,12 +1778,12 @@ export class Client extends ContractClient {
   public readonly fromJSON = {
     initialize_all: this.txFromJSON<null>,
         initialize: this.txFromJSON<null>,
-        deposit: this.txFromJSON<readonly [u128, u128]>,
-        swap: this.txFromJSON<u128>,
+        deposit: this.txFromJSON<readonly [u128, u128, i128]>,
+        swap: this.txFromJSON<readonly [u128, i128, i128]>,
         estimate_swap: this.txFromJSON<readonly [u128, i128]>,
-        swap_strict_receive: this.txFromJSON<u128>,
+        swap_strict_receive: this.txFromJSON<readonly [u128, i128, i128]>,
         estimate_swap_strict_receive: this.txFromJSON<readonly [u128, i128]>,
-        withdraw: this.txFromJSON<u128>,
+        withdraw: this.txFromJSON<readonly [u128, i128]>,
         share_id: this.txFromJSON<string>,
         get_total_shares: this.txFromJSON<u128>,
         get_tokens: this.txFromJSON<Array<string>>,

--- a/contracts/liquidity_calculator/Cargo.toml
+++ b/contracts/liquidity_calculator/Cargo.toml
@@ -13,6 +13,7 @@ access_control = { workspace = true }
 soroban-sdk = { workspace = true }
 soroban-fixed-point-math = { workspace = true }
 upgrade = { workspace = true }
+utils = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/liquidity_calculator/src/constants.rs
+++ b/contracts/liquidity_calculator/src/constants.rs
@@ -1,5 +1,3 @@
-pub(crate) const FEE_MULTIPLIER: u128 = 10_000;
-
 // `PRECISION` is a constant that is used to maintain the precision of calculations.
 // It's a factor by which values are multiplied or divided to maintain precision during arithmetic operations.
 // This is particularly useful when dealing with fractional values in integer calculations,

--- a/contracts/liquidity_calculator/src/standard_pool.rs
+++ b/contracts/liquidity_calculator/src/standard_pool.rs
@@ -1,6 +1,6 @@
-use crate::constants::FEE_MULTIPLIER;
 use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::{Env, Vec};
+use utils::constant::FEE_MULTIPLIER;
 
 // Derivation of the closed-form result for the integral:
 //

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -9,8 +9,8 @@ use crate::interface::{
 use crate::plane::update_plane;
 use crate::plane_interface::Plane;
 use crate::pool::{
-    get_amount_out_strict_receive, get_delta_a, get_net_liquidity_imbalance, get_oracle_price,
-    peg_price, rebalance, update_volume_30d, validate_oracle_price_with_pool,
+    get_amount_out, get_amount_out_strict_receive, get_delta_a, get_net_liquidity_imbalance,
+    get_oracle_price, rebalance, update_volume_30d, validate_oracle_price_with_pool,
 };
 use crate::storage::{
     get_insurance_fund_from_router, get_is_killed_claim, get_is_killed_deposit, get_is_killed_swap,
@@ -484,7 +484,7 @@ impl PoolTrait for Pool {
             panic_with_error!(&e, PoolValidationError::EmptyPool);
         }
 
-        let (out, fee) = pool.get_amount_out(&e, in_amount, reserve_sell, reserve_buy);
+        let out = get_amount_out(in_amount, reserve_sell, reserve_buy);
 
         if out < out_min {
             panic_with_error!(&e, PoolValidationError::OutMinNotSatisfied);
@@ -597,9 +597,7 @@ impl PoolTrait for Pool {
         let reserve_buy = reserves.get(out_idx).unwrap();
 
         let pool = get_pool(&e);
-        let out = pool
-            .get_amount_out(&e, in_amount, reserve_sell, reserve_buy)
-            .0;
+        let out = get_amount_out(in_amount, reserve_sell, reserve_buy);
 
         let base_oracle_price_data = get_oracle_price(&e, &pool.base_asset, NormalAction::Swap);
         let quote_oracle_price_data = get_oracle_price(&e, &pool.quote_asset, NormalAction::Swap);
@@ -683,13 +681,7 @@ impl PoolTrait for Pool {
             panic_with_error!(&e, PoolValidationError::EmptyPool);
         }
 
-        let (in_amount, fee) = get_amount_out_strict_receive(
-            &e,
-            out_amount,
-            reserve_sell,
-            reserve_buy,
-            pool.fee_fraction,
-        );
+        let in_amount = get_amount_out_strict_receive(out_amount, reserve_sell, reserve_buy);
 
         if in_amount > in_max {
             panic_with_error!(&e, PoolValidationError::InMaxNotSatisfied);
@@ -814,14 +806,7 @@ impl PoolTrait for Pool {
         let reserve_buy = reserves.get(out_idx).unwrap();
 
         let pool = get_pool(&e);
-        let out = get_amount_out_strict_receive(
-            &e,
-            out_amount,
-            reserve_sell,
-            reserve_buy,
-            pool.fee_fraction,
-        )
-        .0;
+        let out = get_amount_out_strict_receive(out_amount, reserve_sell, reserve_buy);
 
         let base_oracle_price_data = get_oracle_price(&e, &pool.base_asset, NormalAction::Swap);
         let quote_oracle_price_data = get_oracle_price(&e, &pool.quote_asset, NormalAction::Swap);

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -383,11 +383,15 @@ impl PoolTrait for Pool {
         // update plane data for every pool update
         update_plane(&e);
 
+        // Finds how many synthetic tokens were minted/burned by finding the difference between reserve_a
+        let delta_a: i128 = (reserve_a_after_rebalance as i128).saturating_sub(reserve_a as i128);
+
         LiquidityPoolEvents::new(&e).deposit_liquidity(
             pool.token_b,
             user,
             token_b_amount,
             shares_to_mint,
+            delta_a,
         );
 
         exit(&e);
@@ -460,6 +464,8 @@ impl PoolTrait for Pool {
             action,
         );
 
+        let reserve_a_before_prior_rebalance = get_reserve_a(&e) as i128;
+
         rebalance(
             &e,
             base_oracle_price_data.last_oracle_price_twap,
@@ -470,6 +476,9 @@ impl PoolTrait for Pool {
         let reserve_a = get_reserve_a(&e);
         let reserve_b = get_reserve_b(&e);
         let reserves = Vec::from_array(&e, [reserve_a, reserve_b]);
+
+        let delta_a_prior = reserve_a_before_prior_rebalance.saturating_sub(reserve_a as i128);
+
         let tokens = Self::get_tokens(e.clone());
 
         let (in_idx, out_idx) = if direction == SwapDirection::Buy {
@@ -553,6 +562,9 @@ impl PoolTrait for Pool {
             pool.is_reduce_only(),
         );
 
+        let reserve_a_final = get_reserve_a(&e) as i128;
+        let delta_a_post = reserve_a_final.saturating_sub(reserve_a as i128);
+
         // update plane data for every pool update
         update_plane(&e);
 
@@ -562,7 +574,8 @@ impl PoolTrait for Pool {
             tokens.get(out_idx).unwrap(),
             in_amount,
             out,
-            fee,
+            delta_a_prior,
+            delta_a_post,
         );
 
         exit(&e);
@@ -657,6 +670,8 @@ impl PoolTrait for Pool {
             action,
         );
 
+        let reserve_a_before_prior_rebalance = get_reserve_a(&e) as i128;
+
         rebalance(
             &e,
             base_oracle_price_data.last_oracle_price_twap,
@@ -673,6 +688,9 @@ impl PoolTrait for Pool {
         let reserve_a = get_reserve_a(&e);
         let reserve_b = get_reserve_b(&e);
         let reserves = Vec::from_array(&e, [reserve_a, reserve_b]);
+
+        let delta_a_prior = reserve_a_before_prior_rebalance.saturating_sub(reserve_a as i128);
+
         let tokens = Self::get_tokens(e.clone());
 
         let reserve_sell = reserves.get(in_idx).unwrap();
@@ -751,15 +769,6 @@ impl PoolTrait for Pool {
             transfer_b(&e, &user, out_b);
         }
 
-        LiquidityPoolEvents::new(&e).swap(
-            user.clone(),
-            sell_token,
-            tokens.get(out_idx).unwrap(),
-            in_amount,
-            out_amount,
-            fee,
-        );
-
         // Rebalance the pool
         rebalance(
             &e,
@@ -768,8 +777,21 @@ impl PoolTrait for Pool {
             pool.is_reduce_only(),
         );
 
+        let reserve_a_final = get_reserve_a(&e) as i128;
+        let delta_a_post = reserve_a_final.saturating_sub(reserve_a as i128);
+
         // update plane data for every pool update
         update_plane(&e);
+
+        LiquidityPoolEvents::new(&e).swap(
+            user.clone(),
+            sell_token,
+            tokens.get(out_idx).unwrap(),
+            in_amount,
+            out_amount,
+            delta_a_prior,
+            delta_a_post,
+        );
 
         exit(&e);
 
@@ -874,7 +896,7 @@ impl PoolTrait for Pool {
 
         burn_lp_tokens(&e, &user, share_amount);
 
-        let (_, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
+        let (reserve_a, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
 
         if total_shares - share_amount < MIN_LIQUIDITY {
             panic_with_error!(e, PoolError::WithdrawExceedsMinLiquidity);
@@ -911,6 +933,8 @@ impl PoolTrait for Pool {
             pool.is_reduce_only(),
         );
 
+        let reserve_a_after_rebalance = get_reserve_a(&e);
+
         // Checkpoint resulting working balance
         incentives.manager().update_working_balance(
             &user,
@@ -921,11 +945,15 @@ impl PoolTrait for Pool {
         // update plane data for every pool update
         update_plane(&e);
 
+        // Finds how many synthetic tokens were minted/burned by finding the difference between reserve_a
+        let delta_a: i128 = (reserve_a_after_rebalance as i128).saturating_sub(reserve_a as i128);
+
         LiquidityPoolEvents::new(&e).withdraw_liquidity(
             pool.token_b,
             user,
             share_amount,
             share_amount,
+            delta_a,
         );
 
         exit(&e);

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -258,7 +258,7 @@ impl PoolTrait for Pool {
     // - Transfers Token B to the pool.
     // - Mints LP tokens to the user.
     // - Updates reserves, oracle-based pricing, reward checkpoints, and emits an event.
-    fn deposit(e: Env, user: Address, token_b_amount: u128) -> (u128, u128) {
+    fn deposit(e: Env, user: Address, token_b_amount: u128) -> (u128, u128, i128) {
         user.require_auth();
 
         ensure_non_zero_u128(&e, token_b_amount);
@@ -396,7 +396,7 @@ impl PoolTrait for Pool {
 
         exit(&e);
 
-        (token_b_amount, shares_to_mint)
+        (token_b_amount, shares_to_mint, delta_a)
     }
 
     // Swaps tokens in the pool by transferring an input token from the user and returning an output token,
@@ -436,7 +436,7 @@ impl PoolTrait for Pool {
         direction: SwapDirection,
         in_amount: u128,
         out_min: u128,
-    ) -> u128 {
+    ) -> (u128, i128, i128) {
         user.require_auth();
 
         enter(&e);
@@ -580,7 +580,7 @@ impl PoolTrait for Pool {
 
         exit(&e);
 
-        out
+        (out, delta_a_prior, delta_a_post)
     }
 
     // Estimates the result of a swap operation.
@@ -644,7 +644,7 @@ impl PoolTrait for Pool {
         direction: SwapDirection,
         out_amount: u128,
         in_max: u128,
-    ) -> u128 {
+    ) -> (u128, i128, i128) {
         user.require_auth();
 
         ensure_non_zero_u128(&e, out_amount);
@@ -795,7 +795,7 @@ impl PoolTrait for Pool {
 
         exit(&e);
 
-        in_amount
+        (in_amount, delta_a_prior, delta_a_post)
     }
 
     // Estimates the result of a swap_strict_receive operation.
@@ -873,7 +873,7 @@ impl PoolTrait for Pool {
     // - Rebalances the pool using oracle data.
     // - Updates incentive tracking and on-chain accounting.
     // - Emits a liquidity withdrawal event.
-    fn withdraw(e: Env, user: Address, share_amount: u128) -> u128 {
+    fn withdraw(e: Env, user: Address, share_amount: u128) -> (u128, i128) {
         user.require_auth();
 
         ensure_non_zero_u128(&e, share_amount);
@@ -958,7 +958,7 @@ impl PoolTrait for Pool {
 
         exit(&e);
 
-        share_amount
+        (share_amount, delta_a)
     }
 
     //   _______    _______  ___________  ___________  _______   _______    ________

--- a/contracts/pool/src/events.rs
+++ b/contracts/pool/src/events.rs
@@ -26,9 +26,23 @@ pub trait PoolEvents {
     // |.  \    /:  | /   /  \\  \  /\  |\|    \    \ |
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
-    fn deposit_liquidity(&self, token: Address, user: Address, amount: u128, share_amount: u128);
+    fn deposit_liquidity(
+        &self,
+        token: Address,
+        user: Address,
+        amount: u128,
+        share_amount: u128,
+        delta_a: i128,
+    );
 
-    fn withdraw_liquidity(&self, token: Address, user: Address, share_amount: u128, amount: u128);
+    fn withdraw_liquidity(
+        &self,
+        token: Address,
+        user: Address,
+        share_amount: u128,
+        amount: u128,
+        delta_a: i128,
+    );
 
     fn swap(
         &self,
@@ -37,7 +51,8 @@ pub trait PoolEvents {
         token_out: Address,
         in_amount: u128,
         out_amount: u128,
-        fee_amount: u128,
+        delta_a_prior: i128,
+        delta_a_post: i128,
     );
 
     fn rebalance(
@@ -87,19 +102,33 @@ impl PoolEvents for Events {
     // |.  \    /:  | /   /  \\  \  /\  |\|    \    \ |
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
-    fn deposit_liquidity(&self, token: Address, user: Address, amount: u128, share_amount: u128) {
+    fn deposit_liquidity(
+        &self,
+        token: Address,
+        user: Address,
+        amount: u128,
+        share_amount: u128,
+        delta_a: i128,
+    ) {
         let e = self.env();
         e.events().publish(
             (Symbol::new(e, "deposit_liquidity"), token, user),
-            (amount, share_amount),
+            (amount, share_amount, delta_a),
         );
     }
 
-    fn withdraw_liquidity(&self, token: Address, user: Address, share_amount: u128, amount: u128) {
+    fn withdraw_liquidity(
+        &self,
+        token: Address,
+        user: Address,
+        share_amount: u128,
+        amount: u128,
+        delta_a: i128,
+    ) {
         let e = self.env();
         e.events().publish(
             (Symbol::new(e, "withdraw_liquidity"), token, user),
-            (share_amount, amount),
+            (share_amount, amount, delta_a),
         );
     }
 
@@ -110,12 +139,13 @@ impl PoolEvents for Events {
         token_out: Address,
         in_amount: u128,
         out_amount: u128,
-        fee_amount: u128,
+        delta_a_prior: i128,
+        delta_a_post: i128,
     ) {
         let e = self.env();
         e.events().publish(
             (Symbol::new(e, "swap"), token_in, token_out, user),
-            (in_amount as i128, out_amount as i128, fee_amount as i128),
+            (in_amount, out_amount, delta_a_prior, delta_a_post),
         );
     }
 

--- a/contracts/pool/src/interface.rs
+++ b/contracts/pool/src/interface.rs
@@ -20,7 +20,7 @@ pub trait PoolTrait {
     // |___|\__/|___|(___/    \___)(__\_|_)\___|\____\)
 
     // Add liquidity
-    fn deposit(e: Env, user: Address, token_b_amount: u128) -> (u128, u128);
+    fn deposit(e: Env, user: Address, token_b_amount: u128) -> (u128, u128, i128);
 
     // Perform an exchange between two coins.
     // in_idx: Index value for the coin to send
@@ -34,7 +34,7 @@ pub trait PoolTrait {
         direction: SwapDirection,
         in_amount: u128,
         out_min: u128,
-    ) -> u128;
+    ) -> (u128, i128, i128);
 
     // Estimate amount of coins to retrieve using swap function
     fn estimate_swap(e: Env, direction: SwapDirection, in_amount: u128) -> (u128, i128);
@@ -50,7 +50,7 @@ pub trait PoolTrait {
         direction: SwapDirection,
         out_amount: u128,
         in_max: u128,
-    ) -> u128;
+    ) -> (u128, i128, i128);
 
     // Estimate amount of coins to retrieve using swap_strict_receive function
     fn estimate_swap_strict_receive(
@@ -60,7 +60,7 @@ pub trait PoolTrait {
     ) -> (u128, i128);
 
     // Remove liquidity
-    fn withdraw(e: Env, user: Address, share_amount: u128) -> u128;
+    fn withdraw(e: Env, user: Address, share_amount: u128) -> (u128, i128);
 
     //   _______    _______  ___________  ___________  _______   _______    ________
     //  /" _   "|  /"     "|("     _   ")("     _   ")/"     "| /"      \  /"       )

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -18,10 +18,10 @@ use soroban_sdk::Symbol;
 use soroban_sdk::Vec;
 use soroban_sdk::{panic_with_error, Env};
 
+use utils::constant::PRICE_PRECISION;
 use utils::constant::PRICE_PRECISION_I64;
 use utils::constant::PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128;
 use utils::constant::TWENTY_FOUR_HOUR;
-use utils::constant::{FEE_MULTIPLIER, PRICE_PRECISION};
 use utils::math::safe_math::SafeMath;
 use utils::math::stats::calculate_rolling_sum;
 use utils::state::oracle_registry::HistoricalOracleData;
@@ -377,49 +377,116 @@ pub fn rebalance(e: &Env, base_oracle_price: u128, quote_oracle_price: u128, red
     }
 }
 
-// Calculates the input amount required to receive a fixed output amount in a swap,
-// factoring in the trading fee.
-//
-// This is used in strict-receive swaps where the output is guaranteed and the input
-// is determined. If the total value with fee exceeds the reserve, the function panics.
-//
-// # Arguments
-// * `e` - Soroban environment reference.
-// * `out_amount` - Desired amount of output token to receive.
-// * `reserve_sell` - Reserve of the token being sold.
-// * `reserve_buy` - Reserve of the token being bought.
-// * `fee_fraction` - Trading fee as a fraction (e.g., 30 = 0.3%).
-//
-// # Returns
-// * `(u128, u128)` — Tuple:
-//   - Input amount required to receive `out_amount`
-//   - Fee charged as the difference between input and output value.
-//
-// # Panics
-// - If the fee-adjusted input exceeds available reserves.
+/// Calculates the output amount of tokens for a swap given input and pool reserves.
+///
+/// This function implements a constant product AMM–style formula with fees applied externally (using PoolSwapFee).
+/// The calculation follows:
+///
+/// ```text
+/// out = in * reserve_buy / (reserve_sell + in) - fee
+/// ```
+///
+/// The `fee` portion is not handled inside this function—it must be deducted by the caller
+/// after receiving the raw output value.
+///
+/// # Arguments
+///
+/// * `in_amount` – The amount of input tokens being sold into the pool.
+/// * `reserve_sell` – The current reserve of the token being sold (the pool’s supply of the input token).
+/// * `reserve_buy` – The current reserve of the token being bought (the pool’s supply of the output token).
+///
+/// # Returns
+///
+/// A u128 `amount_out`:
+/// * `amount_out` – The number of output tokens the user would receive before fee deduction.
+///
+/// Returns `0` if `in_amount == 0`.
+///
+/// # Examples
+///
+/// ```rust
+/// // Example reserves
+/// let reserve_sell: u128 = 1_000_000;
+/// let reserve_buy: u128 = 500_000;
+/// let in_amount: u128 = 10_000;
+///
+/// // Calculate output before fee
+/// let out = contract.get_amount_out(in_amount, reserve_sell, reserve_buy);
+///
+/// assert!(out > 0);
+/// ```
+pub fn get_amount_out(in_amount: u128, reserve_sell: u128, reserve_buy: u128) -> u128 {
+    if in_amount == 0 {
+        return 0;
+    }
+
+    // +1 just in case there were some rounding errors & convert to real units in place
+    let result = in_amount
+        .fixed_mul_floor(reserve_buy, reserve_sell.saturating_add(in_amount))
+        .unwrap()
+        + 1;
+
+    result
+}
+
+/// Calculates the required input amount for a **strict receive** swap given
+/// a desired output amount and current pool reserves.
+///
+/// This function computes how much of the *sell token* must be provided in
+/// order to guarantee receiving exactly `out_amount` of the *buy token*,
+/// assuming a constant product AMM invariant.  
+///
+/// The calculation uses a floor division (`fixed_mul_floor`) and then adds
+/// `+1` to the result to guard against rounding errors, ensuring the pool
+/// always receives enough input tokens to cover the desired output.
+///
+/// # Arguments
+///
+/// * `out_amount` – The amount of output tokens the trader wishes to receive.  
+/// * `reserve_sell` – The current reserve of the token being sold
+///   (the pool’s input-side liquidity).  
+/// * `reserve_buy` – The current reserve of the token being bought
+///   (the pool’s output-side liquidity).  
+///
+/// # Returns
+///
+/// * `u128` – The minimum required input amount of the sell token
+///   needed to guarantee the `out_amount` is fulfilled.  
+///   Returns `0` if `out_amount == 0`.  
+///
+/// # Notes
+///
+/// * The extra `+1` ensures rounding errors never result in underpayment.  
+/// * The function does **not** apply protocol or trading fees — callers
+///   must account for those separately if required.  
+///
+/// # Examples
+///
+/// ```rust
+/// let reserve_sell: u128 = 1_000_000;
+/// let reserve_buy: u128 = 500_000;
+/// let desired_out: u128 = 10_000;
+///
+/// // Compute required input for a strict receive
+/// let required_in = contract::get_amount_out_strict_receive(desired_out, reserve_sell, reserve_buy);
+///
+/// assert!(required_in > 0);
+/// ```
 pub fn get_amount_out_strict_receive(
-    e: &Env,
     out_amount: u128,
     reserve_sell: u128,
     reserve_buy: u128,
-    fee_fraction: u32,
-) -> (u128, u128) {
+) -> u128 {
     if out_amount == 0 {
-        return (0, 0);
+        return 0;
     }
 
-    let dy_w_fee = out_amount
-        .fixed_mul_ceil(FEE_MULTIPLIER, (FEE_MULTIPLIER - (fee_fraction as u128)))
-        .unwrap();
-    // if total value including fee is more than the reserve, math can't be done properly
-    if dy_w_fee >= reserve_buy {
-        panic_with_error!(e, PoolValidationError::InsufficientBalance);
-    }
     // +1 just in case there were some rounding errors & convert to real units in place
     let result = reserve_buy
-        .fixed_mul_floor(reserve_sell, (reserve_buy - dy_w_fee))
+        .fixed_mul_floor(reserve_sell, reserve_buy)
         .unwrap()
         - reserve_sell
         + 1;
-    (result, dy_w_fee - out_amount)
+
+    result
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -1,7 +1,6 @@
 use core::cmp::max;
 
 use crate::errors::PoolError;
-use crate::errors::PoolValidationError;
 use crate::events::Events as LiquidityPoolEvents;
 use crate::events::PoolEvents;
 use crate::storage::get_last_trade_ts;

--- a/contracts/pool_router/src/contract.rs
+++ b/contracts/pool_router/src/contract.rs
@@ -90,12 +90,12 @@ impl PoolInterfaceTrait for PoolRouter {
 
         let pool = get_pool(&e, &asset);
 
-        let (amount, share_amount): (u128, u128) = e.invoke_contract(
+        let (amount, share_amount, delta_a): (u128, u128, i128) = e.invoke_contract(
             &pool,
             &symbol_short!("deposit"),
             Vec::from_array(&e, [user.clone().into_val(&e), token_b_amount.into_val(&e)]),
         );
-        Events::new(&e).deposit_liquidity(asset, pool, user, amount, share_amount);
+        Events::new(&e).deposit_liquidity(asset, pool, user, amount, share_amount, delta_a);
 
         exit(&e);
 
@@ -145,10 +145,10 @@ impl PoolInterfaceTrait for PoolRouter {
 
         enter(&e);
 
-        let pool = get_pool(&e, &asset);
+        let pool_address = get_pool(&e, &asset);
 
-        let out_amount = e.invoke_contract(
-            &pool,
+        let (out_amount, delta_a_pre, delta_a_post): (u128, i128, i128) = e.invoke_contract(
+            &pool_address,
             &symbol_short!("swap"),
             Vec::from_array(
                 &e,
@@ -161,7 +161,16 @@ impl PoolInterfaceTrait for PoolRouter {
             ),
         );
 
-        Events::new(&e).swap(asset, pool, user, direction, in_amount, out_amount);
+        Events::new(&e).swap(
+            asset,
+            pool_address,
+            user,
+            direction,
+            in_amount,
+            out_amount,
+            delta_a_pre,
+            delta_a_post,
+        );
 
         exit(&e);
 
@@ -199,10 +208,10 @@ impl PoolInterfaceTrait for PoolRouter {
     ) -> (u128, i128) {
         ensure_non_zero_u128(&e, in_amount);
 
-        let pool_id = get_pool(&e, &asset);
+        let pool_address = get_pool(&e, &asset);
 
         e.invoke_contract(
-            &pool_id,
+            &pool_address,
             &Symbol::new(&e, "estimate_swap"),
             Vec::from_array(&e, [direction.into_val(&e), in_amount.into_val(&e)]),
         )
@@ -235,15 +244,22 @@ impl PoolInterfaceTrait for PoolRouter {
 
         enter(&e);
 
-        let pool = get_pool(&e, &asset);
+        let pool_address = get_pool(&e, &asset);
 
-        let amount: u128 = e.invoke_contract(
-            &pool,
+        let (amount, delta_a): (u128, i128) = e.invoke_contract(
+            &pool_address,
             &symbol_short!("withdraw"),
             Vec::from_array(&e, [user.clone().into_val(&e), share_amount.into_val(&e)]),
         );
 
-        Events::new(&e).withdraw_liquidity(asset, pool, user, share_amount, amount);
+        Events::new(&e).withdraw_liquidity(
+            asset,
+            pool_address,
+            user,
+            share_amount,
+            amount,
+            delta_a,
+        );
 
         exit(&e);
 

--- a/contracts/pool_router/src/events.rs
+++ b/contracts/pool_router/src/events.rs
@@ -24,6 +24,7 @@ pub(crate) trait PoolRouterEvents {
         user: Address,
         amount: u128,
         share_amount: u128,
+        delta_a: i128,
     );
 
     fn swap(
@@ -34,6 +35,8 @@ pub(crate) trait PoolRouterEvents {
         direction: SwapDirection,
         in_amount: u128,
         out_amount: u128,
+        delta_a_pre: i128,
+        delta_a_post: i128,
     );
 
     fn withdraw_liquidity(
@@ -43,6 +46,7 @@ pub(crate) trait PoolRouterEvents {
         user: Address,
         share_amount: u128,
         amount: u128,
+        delta_a: i128,
     );
 
     fn add_pool(&self, asset: Symbol, token_b: Address, pool: Address, init_args: Vec<Val>);
@@ -71,6 +75,7 @@ impl PoolRouterEvents for Events {
         user: Address,
         amount: u128,
         share_amount: u128,
+        delta_a: i128,
     ) {
         self.env().events().publish(
             (
@@ -79,7 +84,7 @@ impl PoolRouterEvents for Events {
                 pool,
                 user,
             ),
-            (amount, share_amount),
+            (amount, share_amount, delta_a),
         );
     }
 
@@ -91,10 +96,12 @@ impl PoolRouterEvents for Events {
         direction: SwapDirection,
         in_amount: u128,
         out_amount: u128,
+        delta_a_pre: i128,
+        delta_a_post: i128,
     ) {
         self.env().events().publish(
             (Symbol::new(self.env(), "swap"), asset, pool, user),
-            (direction, in_amount, out_amount),
+            (direction, in_amount, out_amount, delta_a_pre, delta_a_post),
         );
     }
 
@@ -105,6 +112,7 @@ impl PoolRouterEvents for Events {
         user: Address,
         share_amount: u128,
         amount: u128,
+        delta_a: i128,
     ) {
         self.env().events().publish(
             (
@@ -113,7 +121,7 @@ impl PoolRouterEvents for Events {
                 pool,
                 user,
             ),
-            (share_amount, amount),
+            (share_amount, amount, delta_a),
         );
     }
 
@@ -127,13 +135,13 @@ impl PoolRouterEvents for Events {
     fn delist_pool(&self, asset: Symbol, pool: Address) {
         self.env()
             .events()
-            .publish((Symbol::new(self.env(), "delist_pool"), asset), (pool));
+            .publish((Symbol::new(self.env(), "delist_pool"), asset), pool);
     }
 
     fn remove_pool(&self, asset: Symbol, pool: Address) {
         self.env()
             .events()
-            .publish((Symbol::new(self.env(), "remove_pool"), asset), (pool));
+            .publish((Symbol::new(self.env(), "remove_pool"), asset), pool);
     }
 
     fn config_rewards(&self, asset: Symbol, pool: Address, pool_tps: u128, expired_at: u64) {

--- a/contracts/pool_swap_fee/src/contract.rs
+++ b/contracts/pool_swap_fee/src/contract.rs
@@ -30,7 +30,8 @@ use token_lp::{get_total_lp_tokens, get_user_balance_lp};
 use upgrade::events::Events as UpgradeEvents;
 use upgrade::interface::UpgradeableContract;
 use upgrade::{apply_upgrade, commit_upgrade, revert_upgrade};
-use utils::constant::{FEE_DENOMINATOR, PRICE_PRECISION, THIRTY_DAY};
+use utils::constant::{PRICE_PRECISION, THIRTY_DAY};
+use utils::math::pool::calculate_fee;
 use utils::math::safe_math::SafeMath;
 use utils::math::stats::calculate_rolling_sum;
 use utils::state::pool::{PoolInfo, SwapDirection};
@@ -142,9 +143,8 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
         // Update fee if on token_in
         if direction == SwapDirection::Buy {
             quote_asset_amount = in_amount;
-            fee_amount = (in_amount * (pool_info.pool_response.pool.fee_fraction as u128))
-                / (FEE_DENOMINATOR as u128);
-            in_amount_mut = in_amount - fee_amount;
+            fee_amount = calculate_fee(in_amount, pool_info.pool_response.pool.fee_fraction);
+            in_amount_mut = in_amount.saturating_sub(fee_amount);
         }
 
         e.authorize_as_current_contract(vec![
@@ -181,11 +181,11 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
         // Update fee if on token_out
         if direction == SwapDirection::Sell {
             quote_asset_amount = amount_out;
-            fee_amount = (amount_out * (pool_info.pool_response.pool.fee_fraction as u128))
-                / (FEE_DENOMINATOR as u128);
+            fee_amount = calculate_fee(amount_out, pool_info.pool_response.pool.fee_fraction);
         }
 
-        amount_out_w_fee = amount_out - fee_amount;
+        amount_out_w_fee = amount_out.saturating_sub(fee_amount);
+
         if amount_out_w_fee < out_min {
             panic_with_error!(&e, PoolSwapFeeError::OutMinNotSatisfied);
         }
@@ -208,8 +208,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
 
         // LP FEES
         let lp_revenue_fraction = get_lp_revenue_fraction(&e);
-        let lp_fee_amount =
-            (fee_amount * (lp_revenue_fraction as u128)) / (FEE_DENOMINATOR as u128);
+        let lp_fee_amount = calculate_fee(fee_amount, lp_revenue_fraction);
 
         // Add bounds checking to prevent fee calculation underflow when LP fees exceed total fees
         validate!(
@@ -238,7 +237,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             ),
         );
 
-        let mut if_premium_paid: u128 = 0;
+        let mut insurance_premium_paid: u128 = 0;
 
         if insurance_premium_rate > 0 {
             let estimated_annual_volume = updated_volume_30d.fixed_mul_floor(365, 30).unwrap();
@@ -258,7 +257,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             if insurance_premium_to_pay > 0 {
                 // TODO: must we also call the Pool to update last_revenue_withdraw_ts and rev_withdraw_since_last_settle?
 
-                if_premium_paid = e.invoke_contract(
+                insurance_premium_paid = e.invoke_contract(
                     &insurance_fund,
                     &Symbol::new(&e, "pay_premium"),
                     Vec::from_array(
@@ -283,7 +282,7 @@ impl PoolSwapFeeInterface for PoolSwapFeeCollector {
             amount_out,
             fee_amount,
             lp_fee_amount,
-            if_premium_paid,
+            insurance_premium_paid,
             protocol_fee_amount,
         );
 

--- a/modules/utils/src/constant.rs
+++ b/modules/utils/src/constant.rs
@@ -59,9 +59,6 @@ pub const MIN_LIQUIDITY: u128 = 1_000;
 // Pool Router
 pub const MAX_POOL_FEE: u32 = 100; // 1%
 
-// Swap Fee
-pub const FEE_DENOMINATOR: u32 = 10000;
-
 // Incentives
 pub const REWARD_PRECISION: u128 = 1_000_000_000_000_000_0000000;
 

--- a/modules/utils/src/math/pool.rs
+++ b/modules/utils/src/math/pool.rs
@@ -53,3 +53,47 @@ pub fn sanitize_new_price(
 
     capped_update_price
 }
+
+/// Computes a fee using ceiling rounding in fixed-point arithmetic.
+///
+/// The fee is calculated as:
+///
+/// ```text
+/// fee = ceil(amount * fee_fraction / FEE_MULTIPLIER)
+/// ```
+///
+/// where `fee_fraction` and `FEE_MULTIPLIER` share the same scale
+/// (e.g., `fee_fraction = 30` and `FEE_MULTIPLIER = 10_000` for 30 bps).
+/// Ceiling rounding ensures the protocol never under-collects due to truncation.
+///
+/// # Arguments
+///
+/// * `amount` — The gross amount to which the fee applies.
+/// * `fee_fraction` — The fee numerator in the same scale as `FEE_MULTIPLIER` (e.g., bps).
+///
+/// # Returns
+///
+/// * `u128` — The fee, rounded up (ceiling).
+///   Returns `0` if an overflow occurs inside `fixed_mul_ceil` (current behavior).
+///
+/// # Notes
+///
+/// * This uses `fixed_mul_ceil` and propagates its overflow handling by returning `0`
+///   on `None` via `unwrap_or(0)`. Consider replacing with explicit error handling
+///   if you need to distinguish overflow from a legitimate zero fee.
+///
+/// # Examples
+///
+/// ```rust
+/// // 30 bps on 1_000_000 with ceiling rounding
+/// // fee = ceil(1_000_000 * 30 / 10_000) = ceil(3_000 / 10) = 300
+/// let fee = calculate_fee(1_000_000, 30);
+/// assert_eq!(fee, 300);
+/// ```
+pub fn calculate_fee(amount: u128, fee_fraction: u32) -> u128 {
+    let result = amount
+        .fixed_mul_ceil(fee_fraction as u128, FEE_MULTIPLIER)
+        .unwrap_or(0);
+
+    result
+}

--- a/modules/utils/src/math/pool.rs
+++ b/modules/utils/src/math/pool.rs
@@ -1,9 +1,67 @@
+use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::Env;
 
-use crate::constant::DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR;
+use crate::constant::{DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR, FEE_MULTIPLIER};
 
 use super::safe_math::SafeMath;
 
+/// Sanitizes a new oracle price update by clamping it within a band around the TWAP.
+///
+/// This function guards against abrupt oracle spikes by limiting `new_price` to
+/// a maximum delta from `last_price_twap`. If `sanitize_clamp_denominator` is
+/// non-zero, the allowed price band is:
+///
+/// ```text
+/// band = last_price_twap / sanitize_clamp_denominator
+/// ```
+///
+/// The sanitized price is then:
+///
+/// ```text
+/// if abs(new_price - last_price_twap) > band:
+///     // clamp toward the TWAP edge
+///     capped = last_price_twap ± band
+/// else:
+///     capped = new_price
+/// ```
+///
+/// If `sanitize_clamp_denominator == 0`, no clamping is applied and `new_price` is returned.
+/// If `last_price_twap == 0`, normalization isn’t attempted and `new_price` is returned as-is.
+///
+/// # Arguments
+///
+/// * `e` — Soroban [`Env`] for safe math helpers (e.g., `safe_add`, `safe_sub`, `safe_div`).
+/// * `new_price` — The latest oracle price reading (u128, must be > 0).
+/// * `last_price_twap` — The previous time-weighted average price used as an anchor (u128).
+/// * `sanitize_clamp_denominator` — Denominator controlling the allowed deviation.
+///   - If 0, disables clamping.
+///   - If non-zero, the max deviation is `last_price_twap / sanitize_clamp_denominator`.
+///   - If omitted/0, a default (`DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR`) is used.
+///
+/// # Returns
+///
+/// * `u128` — The sanitized price, clamped to the TWAP band if applicable.
+///
+/// # Panics
+///
+/// * Panics if `new_price == 0`.
+/// * Asserts that `last_price_twap` is non-negative (redundant for `u128`, but retained for clarity).
+///
+/// # Notes
+///
+/// * Uses `safe_*` helpers to avoid overflow/underflow on intermediate arithmetic.
+/// * When clamping downward, if `band >= last_price_twap`, the function returns `0`
+///   to avoid underflow and represent a floor at zero.
+///
+/// # Examples
+///
+/// ```rust
+/// // Allow at most ±1% move from TWAP (denominator 100)
+/// let twap = 100_000u128;
+/// let new = 105_000u128; // +5%
+/// let clamped = sanitize_new_price(&env, new, twap, 100);
+/// assert_eq!(clamped, 101_000); // TWAP + 1% band
+/// ```
 pub fn sanitize_new_price(
     e: &Env,
     new_price: u128,
@@ -12,6 +70,7 @@ pub fn sanitize_new_price(
 ) -> u128 {
     assert!(new_price > 0, "new_price must be positive");
     assert!(last_price_twap >= 0, "last_price_twap must be non-negative");
+
     // when/if twap is 0, dont try to normalize new_price
     if last_price_twap == 0 {
         return new_price;

--- a/modules/utils/src/state/pool.rs
+++ b/modules/utils/src/state/pool.rs
@@ -1,10 +1,7 @@
-use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::contracttype;
 use soroban_sdk::Address;
-use soroban_sdk::Env;
 use soroban_sdk::Symbol;
 
-use crate::constant::FEE_MULTIPLIER;
 use crate::state::access::PrivilegedAddresses;
 use crate::state::token::AddressAndAmount;
 use crate::state::token::TokenInitInfo;

--- a/modules/utils/src/state/pool.rs
+++ b/modules/utils/src/state/pool.rs
@@ -61,23 +61,6 @@ impl Pool {
             PoolTier::Isolated => 10_u64,
         }
     }
-
-    pub fn get_amount_out(
-        &self,
-        e: &Env,
-        in_amount: u128,
-        reserve_sell: u128,
-        reserve_buy: u128,
-    ) -> (u128, u128) {
-        if in_amount == 0 {
-            return (0, 0);
-        }
-
-        // in * reserve_buy / (reserve_sell + in) - fee
-        let result = in_amount.fixed_mul_floor(&e, &reserve_buy, &(reserve_sell + in_amount));
-        let fee = result.fixed_mul_ceil(&e, &(self.fee_fraction as u128), &FEE_MULTIPLIER);
-        (result - fee, fee)
-    }
 }
 
 #[contracttype]


### PR DESCRIPTION
By adding these delta_a values we can show more informative information on the UI in the pool recent events table